### PR TITLE
fix: Remove customer confirmation email

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -78,33 +78,6 @@ export async function POST(request: Request) {
       `,
     });
 
-    // Send confirmation email to the customer
-    await getResend().emails.send({
-      from: `Munden Truck & Equipment <${FROM_EMAIL}>`,
-      to: [email],
-      subject: `We received your message — Munden Truck & Equipment`,
-      html: `
-        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-          <div style="background-color: #7D3038; color: white; padding: 20px; border-radius: 8px 8px 0 0;">
-            <h2 style="margin: 0;">Thank You, ${name}!</h2>
-          </div>
-          <div style="background-color: #f9fafb; padding: 24px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
-            <p>We've received your message and will get back to you as soon as possible.</p>
-            <p>If your matter is urgent, please don't hesitate to call us directly:</p>
-            <p style="font-size: 18px; font-weight: bold;">
-              <a href="tel:250-828-2268" style="color: #7D3038; text-decoration: none;">📞 250-828-2268</a>
-            </p>
-            <p style="color: #6b7280;">We're available 24/7 for emergency service.</p>
-            <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 20px 0;" />
-            <p style="color: #6b7280; font-size: 13px;">
-              <strong>Your message:</strong><br/>
-              ${message}
-            </p>
-          </div>
-        </div>
-      `,
-    });
-
     return NextResponse.json(
       { message: "Contact form submitted successfully" },
       { status: 200 }


### PR DESCRIPTION
Removes the auto-reply email to the customer after contact form submission. The web UI success message is sufficient — no need to spam their inbox too. Shop notification email remains.