### PR TITLE
fix: Update harvester head from Log Max to EcoLog 661LF

### DIFF
--- a/app/equipment/harvesters/[model]/page.tsx
+++ b/app/equipment/harvesters/[model]/page.tsx
@@ -62,7 +62,7 @@ const harvesters = {
         Rotation: "360° continuous",
       },
       "Harvester Head": {
-        "Compatible Models": "Log Max 7000C, Waratah H480C",
+        "Compatible Models": "EcoLog 661LF, Waratah H480C",
         "Max Cutting Diameter": "750 mm",
         "Feed Speed": "5.0 m/s",
         "Feed Force": "25 kN",
@@ -113,7 +113,7 @@ const harvesters = {
         Rotation: "360° continuous",
       },
       "Harvester Head": {
-        "Compatible Models": "Log Max 6000C, Waratah H470C",
+        "Compatible Models": "EcoLog 661LF, Waratah H470C",
         "Max Cutting Diameter": "650 mm",
         "Feed Speed": "4.5 m/s",
         "Feed Force": "22 kN",

--- a/app/equipment/harvesters/page.tsx
+++ b/app/equipment/harvesters/page.tsx
@@ -51,7 +51,7 @@ const harvesters = [
     features: [
       "206 kW Volvo engine",
       "20m reach crane",
-      "Log Max 7000C head",
+      "EcoLog 661LF head",
       "Comfort cab with AutoClimate",
     ],
     specs: {
@@ -70,7 +70,7 @@ const harvesters = [
     features: [
       "190 kW Volvo engine",
       "18m reach crane",
-      "Log Max 6000C head",
+      "EcoLog 661LF head",
       "Ergonomic operator station",
     ],
     specs: {


### PR DESCRIPTION
## Summary
Replace Log Max 6000C and 7000C harvester head references with EcoLog 661LF across the equipment pages.

### Changes
- **Harvesters listing page**: Updated head names in feature lists for both 590G and 580G models
- **Harvester spec pages**: Updated 'Compatible Models' in specifications for both models

### Files Changed
- `app/equipment/harvesters/page.tsx` — feature bullet points
- `app/equipment/harvesters/[model]/page.tsx` — specification tables

### Testing
- `npm run build` passes
- No remaining Log Max references in codebase
- Verified all 4 instances updated correctly

Resolves Todoist task: Update Equipment (munden-trucking)