### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/app/equipment/harvesters/[model]/page.tsx
+++ b/app/equipment/harvesters/[model]/page.tsx
@@ -407,9 +407,9 @@ export default async function HarvesterDetailPage({ params }: Props) {
                     <p className="text-muted-foreground">Max Cut Diameter</p>
                     <p className="font-semibold">
                       {
-                        harvester.specifications["Harvester Head"][
-                          "Max Cutting Diameter"
-                        ]
+                        ("Max Cutting Diameter" in harvester.specifications["Harvester Head"])
+                          ? (harvester.specifications["Harvester Head"] as Record<string, string>)["Max Cutting Diameter"]
+                          : "N/A"
                       }
                     </p>
                   </div>

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
## Changes

- **next.config.ts:** Remove invalid `eslint` key from NextConfig (not supported in Next.js 15+)
- **harvesters/[model]/page.tsx:** Fix `Max Cutting Diameter` property access for the 688G harvester model, which has a different Harvester Head spec structure than 590G/580G (uses Standard Head, Optional Head, Compatible Log Max instead)

## Verification
- `tsc --noEmit` passes with zero errors (was 2 errors before)
- No behavior changes — 688G model now shows 'N/A' for max cut diameter instead of a runtime error

Low-risk: type fixes only, no business logic changes.