### PR TITLE
fix: remove .worktree-meta from repo and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.worktree-meta

--- a/.worktree-meta
+++ b/.worktree-meta
@@ -1,5 +1,0 @@
-agent=jd-builds
-repo=/root/clawd/code/jd-builds/munden-trucking-website
-branch=chore/remove-dead-code
-created=2026-03-06T20:31:32Z
-pid=3806424


### PR DESCRIPTION
Agent internal metadata file (`.worktree-meta`) was accidentally committed in PR #23. Flagged by Lisa QA.

- Removes `.worktree-meta` from the repo
- Adds `.worktree-meta` to `.gitignore` to prevent recurrence

Build: ✅ passes