### PR TITLE
fix: replace FlatCompat with native flat config for eslint-config-next 16

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,3 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import nextConfig from "eslint-config-next";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
-
-const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
-];
-
-export default eslintConfig;
+export default nextConfig;


### PR DESCRIPTION
## Problem
ESLint crashed with `TypeError: Converting circular structure to JSON` because `eslint.config.mjs` used `FlatCompat` to wrap `next/core-web-vitals` and `next/typescript`. With `eslint-config-next@16`, which ships native flat config support, the wrapper creates a circular reference.

## Fix
Replaced the FlatCompat boilerplate with a direct default import from `eslint-config-next` (which now exports a flat config array natively).

## Verified
- `eslint.config.mjs` loads cleanly (no circular structure error)
- `npm run build` passes ✅

fixes #26