### PR TITLE
feat: enhance partner carousel interactions

### DIFF
--- a/components/sections/PartnersLogos.tsx
+++ b/components/sections/PartnersLogos.tsx
@@ -8,13 +8,44 @@ const partners = [
     id: 1,
     name: "British Columbia",
     logo: "/images/partners/british_columbia.jpeg",
+    href: "https://www2.gov.bc.ca/",
   },
-  { id: 2, name: "Carrier", logo: "/images/partners/carrier.png" },
-  { id: 3, name: "EcoLog", logo: "/images/partners/ecolog.png" },
-  { id: 4, name: "Parker", logo: "/images/partners/parker.jpeg" },
-  { id: 5, name: "Webasto", logo: "/images/partners/webasto.png" },
-  { id: 6, name: "ExTe", logo: "/images/partners/exte.jpg" },
-  { id: 7, name: "Grote", logo: "/images/partners/grote.jpg" },
+  {
+    id: 2,
+    name: "Carrier",
+    logo: "/images/partners/carrier.png",
+    href: "https://www.carrier.com/truck-trailer/en/north-america/",
+  },
+  {
+    id: 3,
+    name: "EcoLog",
+    logo: "/images/partners/ecolog.png",
+    href: "https://ecologforestry.com/en/",
+  },
+  {
+    id: 4,
+    name: "Parker",
+    logo: "/images/partners/parker.jpeg",
+    href: "https://www.parker.com/ca/en/home.html",
+  },
+  {
+    id: 5,
+    name: "Webasto",
+    logo: "/images/partners/webasto.png",
+    href: "https://www.webasto.com/en-us/choose-vehicle-solution/heavy-duty-truck.html",
+  },
+  {
+    id: 6,
+    name: "ExTe",
+    logo: "/images/partners/exte.jpg",
+    href: "https://www.exte.se/en/",
+  },
+  {
+    id: 7,
+    name: "Grote",
+    logo: "/images/partners/grote.jpg",
+    href: "https://www.grote.com/",
+  },
 ];
 
 const PartnersLogos = () => {
@@ -43,32 +74,30 @@ const PartnersLogos = () => {
           transition={{ duration: 0.6 }}
           viewport={{ once: true }}
           className="relative overflow-hidden"
-          aria-label="Industry partners"
+          aria-label="Industry partner website links"
         >
-          <ul className="sr-only">
-            {partners.map((partner, index) => (
-              <li key={partner.id}>
-                {index + 1} of {partners.length}: {partner.name}
-              </li>
-            ))}
-          </ul>
-
           <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-16 bg-gradient-to-r from-gray-50 to-transparent" />
           <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-16 bg-gradient-to-l from-gray-50 to-transparent" />
 
-          <div className="py-2" aria-hidden="true">
-            <div className="flex w-max animate-[marquee_34s_linear_infinite] hover:[animation-play-state:paused] motion-reduce:animate-none">
+          <div className="py-5">
+            <div className="flex w-max animate-[marquee_24s_linear_infinite] gap-4 hover:[animation-play-state:paused] focus-within:[animation-play-state:paused] motion-reduce:animate-none">
               {[0, 1].map((groupIndex) => (
                 <div
                   key={groupIndex}
-                  className="flex shrink-0 gap-4 pr-4"
+                  className="flex shrink-0 gap-4"
+                  aria-hidden={groupIndex === 1 ? true : undefined}
                 >
                   {partners.map((partner) => (
-                    <div
+                    <a
                       key={`${groupIndex}-${partner.id}`}
-                      className="flex h-32 w-56 items-center justify-center rounded-lg bg-white p-6 shadow-sm sm:w-64 lg:w-72"
+                      href={partner.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      tabIndex={groupIndex === 1 ? -1 : undefined}
+                      aria-label={`Visit ${partner.name} website (opens in a new tab)`}
+                      className="group/logo relative flex h-32 w-56 shrink-0 cursor-pointer items-center justify-center rounded-lg border border-border/60 bg-white p-6 shadow-sm transition-[border-color,box-shadow,transform] duration-300 ease-out hover:z-20 hover:-translate-y-1 hover:scale-105 hover:border-primary/35 hover:shadow-xl focus-visible:z-20 focus-visible:-translate-y-1 focus-visible:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50 motion-reduce:transition-none sm:w-64 lg:w-72"
                     >
-                      <div className="relative h-20 w-full">
+                      <div className="relative h-20 w-full transition-transform duration-300 ease-out group-hover/logo:scale-110 group-focus-visible/logo:scale-110 motion-reduce:transition-none">
                         <Image
                           src={partner.logo}
                           alt=""
@@ -77,7 +106,7 @@ const PartnersLogos = () => {
                           sizes="(max-width: 640px) 14rem, (max-width: 1024px) 16rem, 18rem"
                         />
                       </div>
-                    </div>
+                    </a>
                   ))}
                 </div>
               ))}

--- a/components/sections/PartnersLogos.tsx
+++ b/components/sections/PartnersLogos.tsx
@@ -49,6 +49,12 @@ const partners = [
 ];
 
 const PartnersLogos = () => {
+  const resumeCarouselAfterClick = (
+    event: React.MouseEvent<HTMLAnchorElement>
+  ) => {
+    event.currentTarget.blur();
+  };
+
   return (
     <section className="py-16 bg-gray-50">
       <div className="container">
@@ -95,6 +101,7 @@ const PartnersLogos = () => {
                       rel="noopener noreferrer"
                       tabIndex={groupIndex === 1 ? -1 : undefined}
                       aria-label={`Visit ${partner.name} website (opens in a new tab)`}
+                      onClick={resumeCarouselAfterClick}
                       className="group/logo relative flex h-32 w-56 shrink-0 cursor-pointer items-center justify-center rounded-lg border border-border/60 bg-white p-6 shadow-sm transition-[border-color,box-shadow,transform] duration-300 ease-out hover:z-20 hover:-translate-y-1 hover:scale-105 hover:border-primary/35 hover:shadow-xl focus-visible:z-20 focus-visible:-translate-y-1 focus-visible:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50 motion-reduce:transition-none sm:w-64 lg:w-72"
                     >
                       <div className="relative h-20 w-full transition-transform duration-300 ease-out group-hover/logo:scale-110 group-focus-visible/logo:scale-110 motion-reduce:transition-none">


### PR DESCRIPTION
## What

- Add official website destinations to each partner logo in the main-page carousel.
- Speed up the marquee from 34s to 24s.
- Make partner logos clickable external link cards that pause the carousel on hover/focus and enlarge the active logo.
- Keep the duplicated marquee group out of keyboard tab order and assistive tech to avoid duplicate navigation.

## Testing

- PATH=/Users/jonah/.nvm/versions/node/v20.19.6/bin:/Users/jonah/.codex/tmp/arg0/codex-arg0G3WrGw:/Users/jonah/.bun/bin:/Users/jonah/.local/bin:/Users/jonah/go_workspace/bin:/Users/jonah/.bun/bin:/opt/homebrew/opt/postgresql@15/bin:/opt/homebrew/opt/openjdk@17/bin:/Users/jonah/.jenv/shims:/Users/jonah/.jenv/bin:/Users/jonah/.nvm/versions/node/v18.19.1/bin:/Users/jonah/google-cloud-sdk/bin:/Users/jonah/.rbenv/shims:/Users/jonah/.rbenv/bin:/opt/homebrew/bin:/opt/homebrew/opt/openjdk@11/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/jonah/.cargo/bin:/Users/jonah/go_workspace/bin:~/google-cloud-sdk/bin:/Users/jonah/Library/Android/sdk/platform-tools:/Users/jonah/.rvm/bin:/Users/jonah/google-cloud-sdk/bin:/Users/jonah/.pub-cache/bin:/Applications/Codex.app/Contents/Resources npm run lint
  - Passes with two existing config warnings in eslint.config.mjs and postcss.config.mjs.
- PATH=/Users/jonah/.nvm/versions/node/v20.19.6/bin:/Users/jonah/.codex/tmp/arg0/codex-arg0G3WrGw:/Users/jonah/.bun/bin:/Users/jonah/.local/bin:/Users/jonah/go_workspace/bin:/Users/jonah/.bun/bin:/opt/homebrew/opt/postgresql@15/bin:/opt/homebrew/opt/openjdk@17/bin:/Users/jonah/.jenv/shims:/Users/jonah/.jenv/bin:/Users/jonah/.nvm/versions/node/v18.19.1/bin:/Users/jonah/google-cloud-sdk/bin:/Users/jonah/.rbenv/shims:/Users/jonah/.rbenv/bin:/opt/homebrew/bin:/opt/homebrew/opt/openjdk@11/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/jonah/.cargo/bin:/Users/jonah/go_workspace/bin:~/google-cloud-sdk/bin:/Users/jonah/Library/Android/sdk/platform-tools:/Users/jonah/.rvm/bin:/Users/jonah/google-cloud-sdk/bin:/Users/jonah/.pub-cache/bin:/Applications/Codex.app/Contents/Resources npm run build
  - Passes. Existing warnings: images.domains deprecation, stale Browserslist data, and edge runtime static-generation note.
- curl -I http://localhost:3000
  - Returns 200 OK.
- Node fetch check against http://localhost:3000
  - Confirms all seven partner URLs render in the main page HTML.

---
_Created by Codex workstation_