### PR TITLE
Fix product snippet structured data

### DIFF
--- a/app/equipment/forwarders/[model]/page.tsx
+++ b/app/equipment/forwarders/[model]/page.tsx
@@ -15,6 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
 import { SpecificationTable } from "@/components/equipment/SpecificationTable";
 import { StructuredData } from "@/components/seo/StructuredData";
+import { absoluteUrl, siteUrl } from "@/lib/site";
 import {
   ChevronLeft,
   Download,
@@ -198,28 +199,24 @@ export default async function ForwarderDetailPage({ params }: Props) {
     notFound();
   }
 
-  const productSchema = {
+  const equipmentPageSchema = {
     "@context": "https://schema.org",
-    "@type": "Product",
-    name: forwarder.model,
+    "@type": "ItemPage",
+    name: `${forwarder.model} Forwarder`,
     description: forwarder.description,
-    brand: {
-      "@type": "Brand",
-      name: "EcoLog",
+    url: `${siteUrl}/equipment/forwarders/${model}`,
+    primaryImageOfPage: {
+      "@type": "ImageObject",
+      url: absoluteUrl(forwarder.image),
     },
-    manufacturer: {
-      "@type": "Organization",
-      name: "EcoLog",
-    },
-    model: forwarder.model,
-    category: "Forestry Equipment > Forwarders",
-    offers: {
-      "@type": "Offer",
-      availability: "https://schema.org/InStock",
-      seller: {
+    mainEntity: {
+      "@type": "Thing",
+      name: forwarder.model,
+      description: forwarder.description,
+      image: absoluteUrl(forwarder.image),
+      manufacturer: {
         "@type": "Organization",
-        name: "Munden Truck & Equipment Ltd.",
-        telephone: "+1-250-828-2268",
+        name: "EcoLog",
       },
     },
   };
@@ -257,7 +254,7 @@ export default async function ForwarderDetailPage({ params }: Props) {
 
   return (
     <>
-      <StructuredData data={productSchema} />
+      <StructuredData data={equipmentPageSchema} />
       <StructuredData data={breadcrumbSchema} />
 
       {/* Hero Section */}

--- a/app/equipment/forwarders/page.tsx
+++ b/app/equipment/forwarders/page.tsx
@@ -92,7 +92,7 @@ const forwarders = [
 ];
 
 export default function ForwardersPage() {
-  const productListSchema = {
+  const equipmentListSchema = {
     "@context": "https://schema.org",
     "@type": "ItemList",
     name: "EcoLog Forwarders",
@@ -103,23 +103,10 @@ export default function ForwardersPage() {
       "@type": "ListItem",
       position: index + 1,
       item: {
-        "@type": "Product",
+        "@type": "WebPage",
         name: forwarder.model,
+        url: `https://mundengroup.ca/equipment/forwarders/${forwarder.id}`,
         description: `${forwarder.type} with ${forwarder.features[0]}`,
-        brand: {
-          "@type": "Brand",
-          name: "EcoLog",
-        },
-        offers: {
-          "@type": "Offer",
-          price: forwarder.price,
-          priceCurrency: "CAD",
-          availability: "https://schema.org/InStock",
-          seller: {
-            "@type": "Organization",
-            name: "Munden Truck & Equipment Ltd.",
-          },
-        },
       },
     })),
   };
@@ -151,7 +138,7 @@ export default function ForwardersPage() {
 
   return (
     <>
-      <StructuredData data={productListSchema} />
+      <StructuredData data={equipmentListSchema} />
       <StructuredData data={breadcrumbSchema} />
 
       {/* Hero Section */}

--- a/app/equipment/harvesters/[model]/page.tsx
+++ b/app/equipment/harvesters/[model]/page.tsx
@@ -15,6 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
 import { SpecificationTable } from "@/components/equipment/SpecificationTable";
 import { StructuredData } from "@/components/seo/StructuredData";
+import { absoluteUrl, siteUrl } from "@/lib/site";
 import {
   ChevronLeft,
   Download,
@@ -259,28 +260,24 @@ export default async function HarvesterDetailPage({ params }: Props) {
     notFound();
   }
 
-  const productSchema = {
+  const equipmentPageSchema = {
     "@context": "https://schema.org",
-    "@type": "Product",
-    name: harvester.model,
+    "@type": "ItemPage",
+    name: `${harvester.model} Harvester`,
     description: harvester.description,
-    brand: {
-      "@type": "Brand",
-      name: "EcoLog",
+    url: `${siteUrl}/equipment/harvesters/${model}`,
+    primaryImageOfPage: {
+      "@type": "ImageObject",
+      url: absoluteUrl(harvester.image),
     },
-    manufacturer: {
-      "@type": "Organization",
-      name: "EcoLog",
-    },
-    model: harvester.model,
-    category: "Forestry Equipment > Harvesters",
-    offers: {
-      "@type": "Offer",
-      availability: "https://schema.org/InStock",
-      seller: {
+    mainEntity: {
+      "@type": "Thing",
+      name: harvester.model,
+      description: harvester.description,
+      image: absoluteUrl(harvester.image),
+      manufacturer: {
         "@type": "Organization",
-        name: "Munden Truck & Equipment Ltd.",
-        telephone: "+1-250-828-2268",
+        name: "EcoLog",
       },
     },
   };
@@ -318,7 +315,7 @@ export default async function HarvesterDetailPage({ params }: Props) {
 
   return (
     <>
-      <StructuredData data={productSchema} />
+      <StructuredData data={equipmentPageSchema} />
       <StructuredData data={breadcrumbSchema} />
 
       {/* Hero Section */}

--- a/app/equipment/harvesters/page.tsx
+++ b/app/equipment/harvesters/page.tsx
@@ -112,7 +112,7 @@ const harvesters = [
 ];
 
 export default function HarvestersPage() {
-  const productListSchema = {
+  const equipmentListSchema = {
     "@context": "https://schema.org",
     "@type": "ItemList",
     name: "EcoLog Harvesters",
@@ -123,23 +123,10 @@ export default function HarvestersPage() {
       "@type": "ListItem",
       position: index + 1,
       item: {
-        "@type": "Product",
+        "@type": "WebPage",
         name: harvester.model,
+        url: `https://mundengroup.ca/equipment/harvesters/${harvester.id}`,
         description: `${harvester.type} with ${harvester.features[0]}`,
-        brand: {
-          "@type": "Brand",
-          name: "EcoLog",
-        },
-        offers: {
-          "@type": "Offer",
-          price: harvester.price,
-          priceCurrency: "CAD",
-          availability: "https://schema.org/InStock",
-          seller: {
-            "@type": "Organization",
-            name: "Munden Truck & Equipment Ltd.",
-          },
-        },
       },
     })),
   };
@@ -171,7 +158,7 @@ export default function HarvestersPage() {
 
   return (
     <>
-      <StructuredData data={productListSchema} />
+      <StructuredData data={equipmentListSchema} />
       <StructuredData data={breadcrumbSchema} />
 
       {/* Hero Section */}

--- a/components/seo/StructuredData.tsx
+++ b/components/seo/StructuredData.tsx
@@ -134,7 +134,7 @@ export const localBusinessSchema = {
         description: "RV repair and maintenance services in Kamloops",
       },
       {
-        "@type": "Product",
+        "@type": "Service",
         name: "Truck Parts",
         description:
           "Truck parts, trailer parts, equipment parts, lubricants, hydraulic hose supply in Kamloops",
@@ -177,30 +177,35 @@ export const productSchema = (product: {
   category: string;
   image?: string;
   price?: string;
-}) => ({
-  "@context": "https://schema.org",
-  "@type": "Product",
-  name: product.name,
-  description: product.description,
-  brand: {
-    "@type": "Brand",
-    name: product.brand,
-  },
-  category: product.category,
-  image: product.image,
-  offers: product.price
-    ? {
-        "@type": "Offer",
-        price: product.price,
-        priceCurrency: "CAD",
-        availability: "https://schema.org/InStock",
-        seller: {
-          "@type": "LocalBusiness",
-          name: "Munden Truck & Equipment Ltd.",
-        },
-      }
-    : undefined,
-});
+}) => {
+  const price = product.price ? Number(product.price) : undefined;
+  const hasNumericPrice = Number.isFinite(price);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": hasNumericPrice ? "Product" : "Thing",
+    name: product.name,
+    description: product.description,
+    brand: {
+      "@type": "Brand",
+      name: product.brand,
+    },
+    category: product.category,
+    image: product.image,
+    offers: hasNumericPrice
+      ? {
+          "@type": "Offer",
+          price,
+          priceCurrency: "CAD",
+          availability: "https://schema.org/InStock",
+          seller: {
+            "@type": "LocalBusiness",
+            name: "Munden Truck & Equipment Ltd.",
+          },
+        }
+      : undefined,
+  };
+};
 
 export const breadcrumbSchema = (
   items: Array<{ name: string; url: string }>,


### PR DESCRIPTION
## Summary
- remove unintended Product markup from the homepage service catalog by treating truck parts as a service catalog item
- replace no-price equipment Product JSON-LD with page/thing markup so Google does not expect offer, review, or rating data that the site cannot honestly provide
- harden the shared product schema helper so it only emits Product rich-result markup when a numeric price is available

## Why
Google Search Console reported a critical Product snippets structured data issue: `Either "offers", "review", or "aggregateRating" should be specified`.

Google's Product snippet documentation requires Product markup to include one of `review`, `aggregateRating`, or `offers`; it also requires Offer prices to be numeric. Since the equipment pages use “Contact for pricing” and do not show product-specific reviews, we should not fake prices or ratings.

## Verification
- `npm run blog:validate`
- `npm run lint` (passes with existing anonymous default export warnings in `eslint.config.mjs` and `postcss.config.mjs`)
- `PATH=/Users/jonah/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build`
- local production checks confirmed:
  - homepage LocalBusiness catalog no longer emits nested Product markup for Truck Parts
  - harvester/forwarder listing pages emit ItemList entries as WebPage, not Product
  - harvester/forwarder detail pages emit ItemPage + Thing markup, not Product/Offer markup

## After deploy
In Search Console, open the Product snippets issue and click **Validate fix** after Vercel finishes deploying this PR.
