### PR TITLE
fix: preserve partial blog backfills

### DIFF
--- a/BLOG_AUTOMATION.md
+++ b/BLOG_AUTOMATION.md
@@ -53,7 +53,7 @@ npm run blog:ensure-images -- --since=2026-05-01
 ```
 
 Use `--dry-run` to preview metadata without writing a file. Use `--date=YYYY-MM-DD` to generate for a specific date.
-Use `blog:backfill` to fill missing publish dates in order. If `--from` is omitted, the script starts with the day after the latest existing post. If `--to` is omitted, it uses today's date in `America/Edmonton`.
+Use `blog:backfill` to fill missing publish dates in order. If `--from` is omitted, the script starts with the day after the latest existing post. If `--to` is omitted, it uses today's date in `America/Edmonton`. If OpenAI returns a long rate-limit reset after one or more posts have been generated, the script stops cleanly so the workflow can validate, build, and commit the partial progress.
 Use `blog:ensure-images` to create unique local/generated images for existing posts from a chosen date onward.
 
 ## Blog Config

--- a/scripts/generate-blog.mjs
+++ b/scripts/generate-blog.mjs
@@ -62,9 +62,26 @@ async function main() {
     console.log(`Backfilling ${dates.length} missing resource post date(s): ${dates.join(", ")}`);
 
     let posts = existingPosts;
+    let generatedCount = 0;
 
     for (const date of dates) {
-      const generatedPost = await generatePostForDate(config, posts, date);
+      let generatedPost = null;
+
+      try {
+        generatedPost = await generatePostForDate(config, posts, date);
+      } catch (error) {
+        if (isLongRateLimitError(error) && generatedCount > 0) {
+          console.warn(
+            `Stopping backfill after ${generatedCount} generated post(s) because OpenAI returned a long rate-limit reset.`,
+          );
+          console.warn(error.message);
+          return;
+        }
+
+        throw error;
+      }
+
+      generatedCount += 1;
 
       if (isDryRun && generatedPost) {
         posts = [generatedPost, ...posts].sort((a, b) => b.date.localeCompare(a.date));


### PR DESCRIPTION
## What

- Lets `blog:backfill` stop cleanly after successful generated posts when OpenAI returns a long rate-limit reset.
- Documents that partial-progress behavior for tight OpenAI quotas.

## Why

The June 18 scheduled run confirmed the API keys are present and working: it generated posts for June 8, June 9, and June 10 and downloaded Pexels images. The run then hit OpenAI `rate_limit_exceeded` on the June 11 post and failed before the commit step, so the successful generated files were discarded.

This change lets that partial progress validate/build/commit instead of being lost.

## Testing

- `node --check scripts/generate-blog.mjs`
- `git diff --check`
- `npm run blog:validate`
- `npm run lint` (passes with existing config warnings)

---
_Created by Codex workstation_
