### PR TITLE
content: manually backfill June resource posts

### DIFF
--- a/content/resources/2026-06-08-exhaust-leaks-mounting-problems-working-truck.md
+++ b/content/resources/2026-06-08-exhaust-leaks-mounting-problems-working-truck.md
@@ -1,0 +1,40 @@
+---
+title: "Exhaust Leaks and Mounting Problems That Can Sideline a Working Truck"
+slug: "exhaust-leaks-mounting-problems-working-truck"
+date: "2026-06-08"
+excerpt: "Exhaust noise, fumes, loose clamps, and broken hangers are easy to dismiss until heat, vibration, or a roadside inspection turns them into downtime. Here is what operators should watch for."
+category: "Maintenance Tips"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/equipment/blog1.jpeg"
+keywords: ["Kamloops truck repair","commercial truck maintenance BC","truck exhaust repair","CVIP inspection Kamloops","mobile truck service Kamloops"]
+sources: [{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"}]
+---
+
+## Why exhaust concerns deserve more than a quick listen
+Exhaust problems often start quietly: a new rattle under the cab, a sharper note under load, a faint smell around the unit, or a bracket that looks a little lower than it used to. Those signs can seem minor when the truck still starts, pulls, and gets through the day. The trouble is that exhaust systems live with heat, vibration, road spray, and repeated movement. A small leak or loose mount can grow quickly.
+
+For Kamloops fleets and operators working across the Interior, the practical concern is uptime. A loose clamp can turn into a broken pipe. A failed hanger can let weight transfer to another section of the system. A leak near heat-sensitive components can create a safety concern. If the truck is heading into a heavy work period, those are problems worth catching before they become road calls.
+
+## Common signs drivers should report
+Drivers do not need to diagnose the full exhaust system. They just need to report useful clues early. Watch for:
+
+- a sudden change in exhaust sound
+- rattling during idle, startup, or shutdown
+- fumes near the cab, sleeper, or work area
+- visible soot around a joint, flex section, clamp, or flange
+- loose heat shields, brackets, or hangers
+- new vibration after rough roads or yard impacts
+- warning lights or performance changes that arrive with exhaust symptoms
+
+The more specific the report, the faster the shop can narrow the inspection. Note when the sound appears, whether it changes under load, and whether the unit recently worked rough roads, construction access, or forestry routes.
+
+## What the shop will usually check
+A service visit should look beyond the loudest point. A technician may inspect clamps, flex sections, hangers, brackets, shields, pipe routing, and nearby wiring or air lines. If one mount has failed, the next question is whether another section has been carrying extra weight. If soot is visible, the leak path matters too.
+
+This is also where inspection readiness comes in. Exhaust leaks, insecure components, and heat-related damage can become more than comfort issues. They can affect whether a truck remains safe and roadworthy. If the concern is tied to a unit that is due for service or inspection, bring it up when booking with the [service department](/services/service-department).
+
+## A practical habit for fleet uptime
+The best approach is simple: do not wait until the system is dragging, loud, or affecting other components. Add exhaust noise, fumes, loose shields, and broken mounts to driver writeups. Take photos if the unit is away from the shop. If it is not clear whether the truck should keep moving, call before sending it on another trip.
+
+For fleets balancing commercial truck maintenance in BC with busy dispatch schedules, that early note can be the difference between a planned repair and an avoidable delay.

--- a/content/resources/2026-06-09-liftgate-warning-signs-that-deserve-service-before-freight-gets-stuck.md
+++ b/content/resources/2026-06-09-liftgate-warning-signs-that-deserve-service-before-freight-gets-stuck.md
@@ -1,0 +1,46 @@
+---
+title: "Liftgate Warning Signs That Deserve Service Before Freight Gets Stuck"
+slug: "liftgate-warning-signs-that-deserve-service-before-freight-gets-stuck"
+date: "2026-06-09"
+excerpt: "A slow, noisy, or unreliable liftgate can turn a normal delivery into a stuck load. These are the signs fleets should document before a small liftgate issue becomes a schedule problem."
+category: "Parts and Service"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/news/steering-suspension.jpg"
+keywords: ["Kamloops trailer repair","truck and trailer parts","commercial truck maintenance BC","mobile truck service Kamloops","fleet maintenance"]
+sources: [{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"}]
+---
+
+## Why liftgate symptoms matter early
+A liftgate is easy to ignore until it refuses to move with freight on board. Before that happens, there are usually smaller clues: slower travel, rough movement, weak lifting, unusual noise, intermittent switches, or a platform that no longer sits the way it should. Those clues are worth reporting because liftgate repairs often involve more than one possible cause.
+
+Hydraulics, wiring, switches, pins, platform hardware, batteries, and charging systems can all affect liftgate performance. If a driver only reports "liftgate issue," the shop has to start from scratch. If the driver reports when it happened, what the gate was lifting, and whether the problem was electrical, hydraulic, or mechanical, the first inspection gets much more productive.
+
+## Signs to document before the next delivery
+Fleets should ask drivers to report liftgate concerns as soon as they appear. Useful signs include:
+
+- platform movement that is slower than usual
+- drifting, sagging, or uneven lifting
+- pump noise that changes or sounds strained
+- visible hydraulic leaks near cylinders, hoses, or fittings
+- switches that work only sometimes
+- loose platform sections, pins, chains, or guards
+- battery or charging concerns on units with heavy liftgate use
+- damage from docks, curbs, yard contact, or rough loading
+
+Photos help, especially when the unit is out of town. A short video can also show whether the problem happens under load, during lowering, or only when the platform is almost closed.
+
+## Parts planning can save a second trip
+Liftgate downtime can be frustrating because the truck may still drive normally while the freight workflow is stuck. That is why parts planning matters. Before booking, gather the unit number, liftgate make and model if available, photos of labels, and a clear description of the symptom. If a part is worn, bent, leaking, or missing, a photo can help the [parts department](/services/parts-department) confirm what is needed before the unit arrives.
+
+Some liftgate work may be straightforward. Other issues need electrical testing, hydraulic checks, or mechanical inspection. Either way, clear information reduces guesswork and helps the shop decide whether the repair belongs in the yard, at the dock, or in the shop.
+
+## Keep delivery equipment part of preventive maintenance
+Liftgates work hard, often in weather and tight delivery spaces. Include them in walkarounds and service notes. Look for leaks, worn pins, weak movement, loose hardware, and damaged controls. Small repairs are easier to plan than a driver calling from a delivery with freight on the gate and no way to move it.
+
+For Kamloops truck and trailer operators, a reliable liftgate is part of keeping freight moving. Treat early warning signs as service information, not background noise.
+
+## What to bring when the unit comes in
+When the truck or trailer is ready for service, bring any notes about how often the gate is used and whether the concern happens loaded or empty. Include the delivery schedule if the unit has a narrow downtime window. If the liftgate is critical to the route, say that up front so the shop can plan diagnosis, parts checks, and repair timing around the work.
+
+It also helps to keep old service notes with the unit. Repeat switch issues, repeated hydraulic leaks, or recurring battery problems may point to a pattern. A little history can prevent the same symptom from being treated like a brand-new problem every time.

--- a/content/resources/2026-06-10-fuel-system-symptoms-to-note-before-a-truck-comes-into-the-shop.md
+++ b/content/resources/2026-06-10-fuel-system-symptoms-to-note-before-a-truck-comes-into-the-shop.md
@@ -1,0 +1,46 @@
+---
+title: "Fuel System Symptoms to Note Before a Truck Comes Into the Shop"
+slug: "fuel-system-symptoms-to-note-before-a-truck-comes-into-the-shop"
+date: "2026-06-10"
+excerpt: "Hard starts, rough idle, power loss, and filter concerns are easier to diagnose when the driver brings useful details. Here is what to record before booking fuel-system service."
+category: "Maintenance Tips"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/equipment/blog1.jpeg"
+keywords: ["Kamloops truck repair","commercial truck maintenance BC","diesel truck service","fleet maintenance","truck repair Kamloops"]
+sources: [{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"}]
+---
+
+## Fuel complaints are easier to solve with context
+Fuel system issues can show up in several ways. A truck may crank longer than usual, idle roughly, lose power under load, stumble on hills, smoke differently, or behave worse after sitting overnight. Those symptoms may point toward fuel supply, filters, air intrusion, contamination, sensor concerns, or another system that needs proper diagnosis.
+
+The important thing is not to guess at the cause from the driver's seat. The important thing is to bring the shop enough detail to recreate the concern and inspect the right areas first. That saves time and reduces the chance of replacing parts without understanding the actual problem.
+
+## Details drivers should write down
+Before a truck comes in, ask the driver or fleet contact to note:
+
+- whether the issue happens cold, warm, loaded, or empty
+- whether it appears at idle, under acceleration, or on grades
+- when fuel filters were last changed
+- whether fuel was recently added from a different site
+- any warning lights, dash messages, or fault codes
+- changes in smoke, smell, or engine sound
+- whether the truck sat for a long period
+- whether the problem is getting worse or comes and goes
+
+If possible, include photos of dash messages and a clear unit number. A short description such as "loses power climbing out of town when loaded, no issue empty" is much more useful than "runs bad."
+
+## Why filter and contamination history matters
+Fuel filters are routine maintenance items, but they also tell a story. Repeated filter plugging, water concerns, or contamination signs should be documented. If a fleet has several units using the same fuel source and more than one unit develops symptoms, that is useful information too.
+
+Technicians may need to inspect filters, lines, fittings, tanks, sensors, and related engine controls. The [service department](/services/service-department) can plan that inspection more effectively when the history is clear. If the truck is away from the shop and the driver is unsure whether it should continue, call before sending it into a harder pull or remote route.
+
+## A practical uptime habit
+Fuel-related symptoms rarely fix themselves. They may improve for a day and return under the wrong load, temperature, or grade. For commercial truck maintenance in BC, early notes help fleets schedule service before a weak-running truck becomes a missed load or roadside call.
+
+Keep a simple record: symptom, conditions, recent fuel or filter work, and any warning lights. That record gives the shop a better starting point and helps fleet managers see whether the issue is isolated to one truck or part of a larger pattern.
+
+## When not to push the truck harder
+If the truck is losing power, showing warning lights, or acting worse under load, do not assume it will clear up on the next trip. A unit that is already struggling may be harder to diagnose after it has been pushed until it fails completely. It may also create a schedule problem in a worse location.
+
+Call the shop with the details before sending the truck into a heavy pull, remote route, or time-sensitive load. The answer may be a planned service visit, a filter check, a diagnostic appointment, or advice to park the unit until it can be inspected safely. Either way, the decision is better when it is made early.

--- a/content/resources/2026-06-11-wheel-end-warning-signs-that-deserve-attention-before-a-long-haul.md
+++ b/content/resources/2026-06-11-wheel-end-warning-signs-that-deserve-attention-before-a-long-haul.md
@@ -1,0 +1,46 @@
+---
+title: "Wheel-End Warning Signs That Deserve Attention Before a Long Haul"
+slug: "wheel-end-warning-signs-that-deserve-attention-before-a-long-haul"
+date: "2026-06-11"
+excerpt: "Heat, noise, seals, hub oil, and tire wear can all point to wheel-end trouble. A few minutes of attention before a long haul can prevent bigger downtime later."
+category: "Maintenance Tips"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/news/steering-suspension.jpg"
+keywords: ["CVIP inspection Kamloops","commercial truck maintenance BC","Kamloops trailer repair","wheel end inspection","fleet maintenance"]
+sources: [{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"}]
+---
+
+## Why wheel ends deserve a careful look
+Wheel-end issues are not the place for guesswork. Bearings, seals, hubs, brakes, tires, and suspension all work close together, and a concern in one area can affect the rest. Before a long haul or a heavy work stretch, small signs around the wheel end deserve attention because the cost of failure on the road is much higher than the cost of a planned inspection.
+
+Operators do not need to take anything apart during a walkaround. They need to notice changes and report them clearly. Heat, smell, oil, noise, vibration, or unusual tire wear should all be treated as useful information.
+
+## Signs drivers and fleet managers should note
+During pre-trip checks and service planning, watch for:
+
+- oil or grease around hub caps, seals, wheels, or brake components
+- one wheel position running hotter than the others
+- new rumbling, grinding, or growling sounds
+- vibration that changes with speed
+- uneven tire wear or cupping
+- brake smell or dragging symptoms
+- loose or damaged hub caps
+- recent wheel-end, brake, tire, or suspension work
+
+If a wheel position seems unusually hot, do not ignore it. Let the unit cool safely, compare it with the others, and call for guidance if there is any doubt.
+
+## Inspection timing and CVIP readiness
+Wheel-end condition matters for everyday safety and inspection readiness. A truck or trailer can look fine from a distance while a seal, bearing, brake, or tire issue is already developing. Keeping records of driver reports, recent repairs, and recurring tire wear helps technicians connect the dots.
+
+If a unit is due for inspection or has been working hard on grades, rough roads, or heavy loads, schedule time with the [service department](/services/service-department). A planned inspection can check the concern before it turns into heat damage, brake damage, or a roadside stop.
+
+## Keep notes specific
+"Wheel noise" is a start. "Right rear trailer position started rumbling above highway speed after the last load" is better. Specific notes help the shop road-test, inspect, and prioritize the correct area.
+
+For fleets in Kamloops and the BC Interior, wheel-end attention is one of those maintenance habits that pays for itself by avoiding surprises. Build it into driver writeups, shop visits, and preventive maintenance planning.
+
+## Use records to spot repeat positions
+Wheel-end concerns are easier to manage when fleets track which position keeps showing symptoms. If the same trailer position has repeat seal concerns, heat complaints, or tire wear, that history should follow the unit into the shop. It can point toward a deeper issue than a single failed part.
+
+Keep notes from tire work, brake work, bearing service, and inspection findings together. When the next driver reports a vibration or heat concern, the shop can compare it with the previous repair history instead of starting from zero.

--- a/content/resources/2026-06-12-fifth-wheel-inspection-points-that-help-prevent-coupling-problems.md
+++ b/content/resources/2026-06-12-fifth-wheel-inspection-points-that-help-prevent-coupling-problems.md
@@ -1,0 +1,46 @@
+---
+title: "Fifth Wheel Inspection Points That Help Prevent Coupling Problems"
+slug: "fifth-wheel-inspection-points-that-help-prevent-coupling-problems"
+date: "2026-06-12"
+excerpt: "Coupling issues can create serious delays and safety concerns. These fifth wheel inspection habits help drivers and fleets catch wear, adjustment, and lubrication problems earlier."
+category: "Maintenance Tips"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/equipment/blog1.jpeg"
+keywords: ["commercial truck maintenance BC","Kamloops truck repair","CVIP inspection Kamloops","fleet maintenance","truck inspection"]
+sources: [{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"}]
+---
+
+## Coupling problems are worth preventing
+A fifth wheel works quietly until something is wrong. Then the problem can affect dispatch, safety, inspections, and confidence in the unit. Wear, poor lubrication, damaged components, or adjustment concerns can make coupling harder, create movement, or lead to repeated driver complaints.
+
+Because the fifth wheel is part of a high-load connection, inspection habits matter. Drivers should follow their required coupling procedures and report anything that feels different. Fleet managers should treat repeated comments as a maintenance signal, not a personality difference between drivers.
+
+## What to look for during routine checks
+Useful inspection points include:
+
+- condition and movement of the release handle
+- visible damage or unusual wear around the locking area
+- plate condition and lubrication
+- loose, missing, or damaged mounting fasteners
+- cracks, rust trails, or movement around mounts
+- coupling difficulty with more than one trailer
+- unusual clunking, shifting, or movement during operation
+- driver notes about failed or rough coupling attempts
+
+Drivers should never force a questionable coupling situation and hope it will settle in. If something feels wrong, stop and get the connection checked.
+
+## Why details help the shop
+Fifth wheel concerns can be related to the tractor, trailer, kingpin, adjustment, lubrication, wear, or driver procedure. That means good notes matter. Did the issue happen with one trailer or several? Did it happen after a yard impact? Was the plate dry? Did the handle move normally? Did the driver notice extra movement on the road?
+
+Bring those details to the [service department](/services/service-department). A technician can inspect the fifth wheel, mounts, locking components, plate condition, and related trailer connection points. If parts are needed, the unit number and component details help reduce delays.
+
+## Make fifth wheel checks part of fleet planning
+Fifth wheel inspection should not wait until a truck refuses to couple at the worst possible time. Add coupling complaints to maintenance records, especially if they repeat. Watch for lubrication habits, yard conditions, and trailers that seem to create the same issue across multiple tractors.
+
+For commercial truck maintenance in BC, the goal is straightforward: protect the connection, reduce avoidable downtime, and make sure drivers trust the equipment before they leave the yard.
+
+## Treat driver confidence as useful information
+A driver who says a fifth wheel does not feel right may not have the exact mechanical answer, but the comment still matters. Coupling equipment is familiar to experienced operators. If the handle movement, lock feel, or road movement changes, that change should be written down and checked.
+
+Fleet managers can help by making those reports easy to submit without blame. The earlier the note arrives, the easier it is to inspect the fifth wheel, compare it with trailer history, and decide whether service is needed before the next dispatch.

--- a/content/resources/2026-06-13-abs-warning-light-basics-for-truck-and-trailer-operators.md
+++ b/content/resources/2026-06-13-abs-warning-light-basics-for-truck-and-trailer-operators.md
@@ -1,0 +1,45 @@
+---
+title: "ABS Warning Light Basics for Truck and Trailer Operators"
+slug: "abs-warning-light-basics-for-truck-and-trailer-operators"
+date: "2026-06-13"
+excerpt: "An ABS light does not explain the whole problem, but it is a useful clue. Here is how operators can document ABS warnings before they become inspection or downtime concerns."
+category: "Maintenance Tips"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/news/steering-suspension.jpg"
+keywords: ["Kamloops trailer repair","CVIP inspection Kamloops","commercial truck maintenance BC","ABS warning light","truck repair Kamloops"]
+sources: [{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"}]
+---
+
+## ABS lights are clues, not full diagnoses
+When an ABS warning light appears, it is tempting to think of it as a simple light problem. In reality, it can point toward sensors, wiring, tone rings, connectors, power supply concerns, or faults that need proper testing. The light tells the driver that the system needs attention; it does not tell the whole story by itself.
+
+For truck and trailer operators, the best first step is to document what happened. Did the light come on at startup? Did it appear after connecting a trailer? Did it flicker on rough roads? Did it stay on after cycling the ignition? That context helps the shop inspect the right area first.
+
+## Information to gather before service
+Useful ABS notes include:
+
+- whether the light is on the tractor, trailer, or both
+- when it appears and whether it clears
+- recent trailer swaps or electrical repairs
+- rough-road operation before the warning appeared
+- visible damage to cords, plugs, or wiring
+- wheel-end, brake, or suspension work done recently
+- any other dash messages or warning lights
+
+Photos of the dash and trailer light behavior can help. If the issue is intermittent, a short timeline is better than trying to remember the details days later.
+
+## Why wiring and wheel-end history matter
+ABS concerns often involve areas exposed to weather, vibration, road debris, and repeated trailer connections. Wiring and connectors can be damaged or corroded. Wheel-end work can disturb sensor areas. Rough roads can turn a marginal connection into an intermittent fault.
+
+That is why a service visit should include the story, not just the light. The [service department](/services/service-department) can inspect, test, and trace the concern more efficiently when technicians know what changed before the warning appeared.
+
+## Do not wait until inspection day
+ABS warnings can become inspection and scheduling issues if they are ignored until a deadline. Fleet managers should track repeated ABS complaints and avoid sending the same unresolved issue from one driver to the next.
+
+For Kamloops truck repair and trailer repair, early ABS documentation is practical: it helps prevent avoidable delays, gives technicians a clearer starting point, and supports safer equipment on the road.
+
+## Do not erase the clues too quickly
+If an ABS warning appears, try to capture the details before the unit is cycled, swapped, or moved around the yard. A photo of the light, the trailer number, and the conditions can help later if the fault clears temporarily. Intermittent electrical concerns are often the hardest to chase when the only note is that the light was "on earlier."
+
+That does not mean delaying safe decisions. It means preserving useful information while the symptom is present. The more complete the first report, the less time technicians spend trying to recreate a problem that only appears under certain conditions.

--- a/content/resources/2026-06-14-frame-and-crossmember-cracks-that-should-be-checked-before-hauling-heavy.md
+++ b/content/resources/2026-06-14-frame-and-crossmember-cracks-that-should-be-checked-before-hauling-heavy.md
@@ -1,0 +1,46 @@
+---
+title: "Frame and Crossmember Cracks That Should Be Checked Before Hauling Heavy"
+slug: "frame-and-crossmember-cracks-that-should-be-checked-before-hauling-heavy"
+date: "2026-06-14"
+excerpt: "Frame-area cracks, rust trails, and damaged crossmembers should be inspected before heavy work exposes a weak point. Here is what fleets should look for and document."
+category: "Equipment Guides"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/equipment/blog1.jpeg"
+keywords: ["Kamloops truck repair","Kamloops trailer repair","commercial truck maintenance BC","welding and fabrication","fleet maintenance"]
+sources: [{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"}]
+---
+
+## Structural concerns should not be guessed at
+Frame and crossmember issues can start as small cracks, rust trails, loose mounts, or hardware that no longer sits correctly. Those signs may not stop a truck or trailer right away, but they deserve attention before the unit is sent into heavy hauling, rough roads, or remote work.
+
+Structural areas carry load and absorb movement. A small visible crack can be only part of the issue. Nearby brackets, mounts, suspension points, and previous repair areas may also need inspection. The safest habit is to document the concern and have it checked before deciding the unit is ready.
+
+## Walkaround signs worth reporting
+Drivers and yard staff should report:
+
+- visible cracks around crossmembers, mounts, brackets, or frame-area components
+- rust lines that suggest movement around a crack
+- loose or missing fasteners
+- shifted brackets or hardware
+- damage after an impact, curb strike, or yard incident
+- repeat cracks near a previous repair
+- new noise or movement under load
+- sagging or alignment changes that were not there before
+
+Photos should include both a close view and a wider view showing where the concern sits on the unit. That helps the shop understand access, load path, and nearby components.
+
+## Repair planning matters
+Not every visible crack means the same repair. Some concerns need a straightforward fix. Others need fabrication planning, reinforcement, hardware replacement, or inspection of related parts. A technician may also need to understand how the equipment is used so the repair fits the work, not just the visible break.
+
+Bring the unit history to the [service department](/services/service-department): recent loads, rough-road use, prior repairs, and whether the issue is growing. If the unit should not be driven, ask before moving it.
+
+## Protect uptime before heavy work
+Heavy hauling and rough conditions expose weak points. Checking frame and crossmember concerns early gives fleet managers a chance to plan repairs instead of reacting to a bigger failure.
+
+For Kamloops truck repair, trailer repair, and equipment support across the Interior, the rule is simple: structural damage deserves a real inspection before the next hard job.
+
+## Keep repair history with the unit
+Structural repairs should not disappear from the maintenance record once the unit is back on the road. Keep notes about what was repaired, where reinforcement was added, and whether related parts were replaced. If a crack returns nearby, that history matters.
+
+Photos before and after repair can also be useful. They give fleet managers a reference point during later walkarounds and help technicians understand whether a new concern is related to an old repair or a different stress point. Good records turn a one-time fix into better long-term maintenance planning.

--- a/content/resources/2026-06-15-pto-and-wet-kit-maintenance-questions-to-ask-before-a-busy-job.md
+++ b/content/resources/2026-06-15-pto-and-wet-kit-maintenance-questions-to-ask-before-a-busy-job.md
@@ -1,0 +1,46 @@
+---
+title: "PTO and Wet Kit Maintenance Questions to Ask Before a Busy Job"
+slug: "pto-and-wet-kit-maintenance-questions-to-ask-before-a-busy-job"
+date: "2026-06-15"
+excerpt: "PTO and wet kit problems can slow down jobs that depend on hydraulic power. Ask these practical questions before the truck is committed to busy work."
+category: "Maintenance Tips"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/equipment/blog1.jpeg"
+keywords: ["Kamloops truck repair","commercial truck maintenance BC","hydraulic repair","fleet maintenance","truck service"]
+sources: [{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"}]
+---
+
+## Busy jobs expose weak hydraulic support
+PTO and wet kit concerns often show up when a truck is finally asked to work hard. Engagement problems, leaks, noise, heat, slow operation, or control issues can turn a scheduled job into downtime. Before a busy period, it is worth asking a few practical questions about the system.
+
+The goal is not to turn every driver into a hydraulic technician. The goal is to catch symptoms early and give the shop enough information to inspect safely and efficiently.
+
+## Questions to ask before dispatch
+Before committing a unit to work that depends on PTO or hydraulic power, ask:
+
+- Does the PTO engage smoothly and consistently?
+- Has the operator noticed new noise, vibration, or delay?
+- Are there leaks around hoses, fittings, tanks, pumps, or valves?
+- Is fluid level being monitored and documented?
+- Has any hose rubbed, cracked, or started to seep?
+- Do controls respond the same way every time?
+- Has the truck recently had hydraulic or driveline work?
+- Is the unit being used differently than before?
+
+If the answer to any question is unclear, inspect before the job becomes urgent.
+
+## Why notes help the repair process
+PTO and wet kit issues can involve mechanical, hydraulic, electrical, and operator-control concerns. A symptom such as "slow operation" can have several causes. Details about when it happens, what the truck is powering, and whether the concern changes with temperature or load are useful.
+
+When booking with the [service department](/services/service-department), include photos of leaks, hose routing, labels, and the unit number. If parts may be needed, early information helps reduce wrong-fit delays and repeat calls.
+
+## A planning habit for working trucks
+Hydraulic support equipment should be part of preventive maintenance, especially before seasonal peaks or demanding jobs. Look for leaks, rubbing hoses, loose mounts, damaged guards, and controls that no longer feel normal.
+
+For fleets in Kamloops and the BC Interior, planned PTO and wet kit checks help keep working trucks productive. A small service window before the job is usually easier to manage than a stuck unit once the work has started.
+
+## Match the inspection to the work
+A truck that only uses hydraulic equipment occasionally may need a different service conversation than a unit that depends on it every day. Tell the shop how the system is being used, what it powers, and whether the next job will be harder than normal. That context helps with inspection priorities.
+
+If operators have been topping up fluid, hearing new noise, or noticing slower movement, bring those details in early. A hydraulic issue that seems manageable in the yard can become a much bigger problem once the truck is committed to a busy site.

--- a/content/resources/2026-06-16-parts-ordering-details-that-reduce-repeat-calls-and-wrong-fit-delays.md
+++ b/content/resources/2026-06-16-parts-ordering-details-that-reduce-repeat-calls-and-wrong-fit-delays.md
@@ -1,0 +1,47 @@
+---
+title: "Parts Ordering Details That Reduce Repeat Calls and Wrong-Fit Delays"
+slug: "parts-ordering-details-that-reduce-repeat-calls-and-wrong-fit-delays"
+date: "2026-06-16"
+excerpt: "The right part is easier to find when the first call includes the right details. Unit numbers, photos, measurements, and old part markings can all prevent delays."
+category: "Parts and Service"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/equipment/blog1.jpeg"
+keywords: ["truck and trailer parts","Kamloops truck repair","Kamloops trailer repair","commercial truck maintenance BC","parts department"]
+sources: [{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"}]
+---
+
+## Good parts calls start with good details
+Wrong-fit parts waste time. They can hold up a bay, delay a driver, or turn a simple repair into multiple calls. The good news is that many parts delays can be reduced by gathering the right details before calling.
+
+For trucks, trailers, and equipment, small differences matter. Model year, axle position, suspension setup, body configuration, previous repairs, and aftermarket changes can all affect what fits. A general description may get the conversation started, but exact details help the parts team narrow the search.
+
+## What to gather before calling
+Before contacting the parts counter, collect:
+
+- unit number and VIN
+- make, model, and year when available
+- serial numbers or component tags
+- clear photos of the part and where it mounts
+- old part numbers, casting numbers, or label information
+- measurements when the part is not easily identified
+- left/right or driver/passenger side details
+- symptoms if the part failed in use
+- related hardware that may also be needed
+
+Photos should include a wide shot for context and a close shot for markings. If the old part is damaged, show both the damage and any intact identifying information.
+
+## Why application details matter
+The same basic part description can cover several variations. A valve, light, hanger, hose, seal, or bracket may change based on application. Trailer parts can vary by axle, suspension, door style, wiring setup, or body configuration. Equipment parts may depend on serial number and attachment details.
+
+The [parts department](/services/parts-department) can work faster when the first call includes the real application, not just the part name. If the repair is already scheduled, include timing and whether the unit can stay down while the part is confirmed.
+
+## Build a simple fleet habit
+Encourage drivers and shop staff to take photos before removing parts. Keep unit records current. Save old labels when possible. Track repeat failures so the parts conversation includes the larger problem, not only the replacement item.
+
+For Kamloops truck and trailer operators, better parts information means fewer wrong turns, fewer repeat calls, and a smoother path from diagnosis to repair.
+
+## Save the information after the repair
+Once the right part is found, keep the useful information with the unit record. Part numbers, photos, supplier notes, and fitment details can save time the next time that unit needs service. This is especially helpful for mixed fleets, older trailers, specialty equipment, and units with previous modifications.
+
+Good records also help new staff. If the person who solved the last parts puzzle is away, the next call does not need to start from the beginning. A few saved details can turn a difficult lookup into a routine reorder.

--- a/content/resources/2026-06-17-logging-truck-maintenance-notes-that-matter-after-rough-bush-roads.md
+++ b/content/resources/2026-06-17-logging-truck-maintenance-notes-that-matter-after-rough-bush-roads.md
@@ -1,0 +1,50 @@
+---
+title: "Logging Truck Maintenance Notes That Matter After Rough Bush Roads"
+slug: "logging-truck-maintenance-notes-that-matter-after-rough-bush-roads"
+date: "2026-06-17"
+excerpt: "Rough bush roads can shake loose problems that do not show up on pavement. These are the maintenance notes logging truck operators should bring back from the field."
+category: "Forestry Equipment"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/equipment/590g-harvester.jpg"
+keywords: ["forestry equipment Western Canada","commercial truck maintenance BC","Kamloops truck repair","logging truck maintenance","EcoLog dealer Western Canada"]
+sources: [{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"}]
+---
+
+## Rough roads change the maintenance picture
+Logging trucks and forestry support equipment often work where vibration, dust, mud, grades, and uneven ground are part of the job. A unit may feel fine on pavement and still come back from bush roads with new rattles, loose hardware, wiring concerns, or wear that deserves attention.
+
+That is why operator notes matter. The shop cannot see every road condition the unit worked through. A short, specific note from the field can point technicians toward the right inspection before a small concern becomes downtime.
+
+## Notes worth bringing back from the field
+After rough-road work, operators should report:
+
+- new rattles, clunks, or vibration
+- lighting or wiring issues that appear intermittently
+- loose steps, guards, brackets, or mounts
+- air line or hose rubbing
+- tire damage, uneven wear, or impact marks
+- brake smell, heat, or changed pedal feel
+- suspension noise or visible damage
+- dust-related filter concerns
+- any impact, bottoming, or unusual load event
+
+Photos are helpful when the unit is still in the field. A wide shot plus a closeup can save time when planning service or parts.
+
+## Forestry work needs practical planning
+Forestry operations depend on uptime, but they also put equipment into conditions that are hard on components. Maintenance planning should include the truck, trailer, and related forestry equipment support. If a crew is also running harvesters, forwarders, or other equipment, shared notes about hoses, guards, filters, and wear items can help the team plan ahead.
+
+For EcoLog equipment questions or forestry support planning, start with [EcoLog forestry equipment support](/equipment/ecolog). For truck and trailer concerns, bring field notes to the service team so the inspection matches the work the unit actually performed.
+
+## Do not let small field clues disappear
+The biggest risk with rough-road symptoms is forgetting them once the unit gets back to the yard. Build a simple habit: note the symptom, location, operating condition, and whether it changed during the day. That record helps Kamloops and Interior fleets make better service decisions before the next remote job.
+
+## Plan parts and service before the next remote run
+Remote work makes small parts delays feel bigger. If a unit comes back with damaged lights, worn hoses, loose guards, or repeat wiring issues, check parts availability before the next dispatch. The same applies to filters, fittings, and wear items that crews already know they will need.
+
+Planning does not remove every surprise, but it gives the crew a better chance of handling known issues at the yard instead of far from support. For forestry contractors, that preparation is part of keeping trucks and equipment available when the work window is open.
+
+## Connect truck notes with equipment notes
+Logging operations rarely depend on one machine alone. If trucks, trailers, harvesters, and forwarders are all working the same rough access, maintenance notes should be shared across the operation. A road condition that damages lights or loosens brackets on a truck may also be hard on hoses, guards, and fittings on equipment.
+
+That broader view helps crews prioritize. If several units show dust, vibration, or impact-related issues after the same job, it may be time to schedule a more complete inspection window rather than fixing each symptom one at a time.

--- a/content/resources/2026-06-18-mobile-service-call-details-that-help-technicians-arrive-prepared.md
+++ b/content/resources/2026-06-18-mobile-service-call-details-that-help-technicians-arrive-prepared.md
@@ -1,0 +1,47 @@
+---
+title: "Mobile Service Call Details That Help Technicians Arrive Prepared"
+slug: "mobile-service-call-details-that-help-technicians-arrive-prepared"
+date: "2026-06-18"
+excerpt: "A mobile service call goes better when the first conversation includes location, symptoms, unit details, access, and safety notes. Here is what to gather before calling."
+category: "Parts and Service"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/equipment/blog1.jpeg"
+keywords: ["mobile truck service Kamloops","Kamloops truck repair","commercial truck maintenance BC","truck and trailer parts","fleet maintenance"]
+sources: [{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"}]
+---
+
+## The first call shapes the service response
+Mobile service is most useful when the technician has a clear picture before leaving. A truck that will not start in a yard, a trailer with an air concern on a job site, and a unit stopped on the roadside all need different planning. The first call should help decide what can be done safely on site and what may need a shop or tow plan.
+
+Good information does not guarantee every repair can happen in the field, but it does help the technician arrive with better expectations, tools, and parts possibilities.
+
+## Details to gather before calling
+Before requesting mobile support, collect:
+
+- exact location, access notes, and safe parking information
+- unit number, make, model, and trailer details if relevant
+- driver or site contact name and phone number
+- clear symptom description
+- dash messages, warning lights, or fault codes
+- photos of the problem area
+- whether the unit is loaded or empty
+- whether air, electrical, hydraulic, fuel, or cooling concerns are involved
+- weather, road, or site conditions that affect access
+
+If the unit is in an unsafe location, address safety first. The repair plan should never put the driver, technician, or other road users at risk.
+
+## Photos and symptoms reduce guesswork
+A few photos can answer questions that are hard to explain over the phone. Show the whole unit, the affected area, any labels or part numbers, and visible leaks or damage. If a warning message is on the dash, photograph it before cycling power.
+
+When contacting [mobile service](/services/mobile-service), explain what changed and when. "Trailer is losing air after coupling, audible leak near left front, loaded in yard with safe access" gives the team much more to work with than "air problem."
+
+## Know when the shop is the better answer
+Some issues can be assessed or repaired on site. Others need controlled shop conditions, lifting equipment, deeper diagnostics, or parts that are not practical to bring on a first call. A good mobile service conversation helps decide the next step, even if the answer is not a field repair.
+
+For fleets in Kamloops and the BC Interior, clear mobile-service details help reduce downtime, avoid wasted trips, and get the right support moving sooner.
+
+## Make the next call easier
+After a mobile service visit, keep the notes with the unit record. Record what was found, what was repaired, what still needs shop follow-up, and whether any parts were temporary or should be replaced later. That follow-up matters because a field repair may solve the immediate problem while still pointing to future maintenance.
+
+Drivers and dispatchers should also note what information was missing on the first call. If access directions, photos, or unit details slowed the response, add them to the fleet's normal call checklist. The next service call will be cleaner because the team learned from the last one.


### PR DESCRIPTION
## What

- Adds manually written resource posts for the missing June 8 through June 18 publishing dates.
- Uses existing site image assets to avoid OpenAI/Pexels quota dependence.
- Keeps each post's visible date, frontmatter date, sitemap date, and BlogPosting `datePublished`/`dateModified` consistent with the backfilled date.

## Google/Search Console note

This is safe as a content recovery backfill: the pages are normal indexable resource URLs, the dates are consistent on-page and in structured data, and the existing sitemap will include the new URLs after deploy. Google's guidance is to keep page dates consistent and to use sitemap `lastmod` for meaningful content changes; these posts satisfy that pattern.

## Testing

- `npm run blog:validate`
- `npm run lint` (passes with existing config warnings)
- `npm run build`

---
_Created by Codex workstation_
