### PR TITLE
fix: strengthen canonical SEO signals

### DIFF
--- a/app/about/careers/page.tsx
+++ b/app/about/careers/page.tsx
@@ -103,7 +103,6 @@ const processSteps = [
 export default function CareersPage() {
   const breadcrumbs = [
     { name: "Home", url: "https://mundengroup.ca" },
-    { name: "About", url: "https://mundengroup.ca/about" },
     { name: "Careers", url: "https://mundengroup.ca/about/careers" },
   ];
 

--- a/app/about/history/page.tsx
+++ b/app/about/history/page.tsx
@@ -98,7 +98,6 @@ const values = [
 export default function HistoryPage() {
   const breadcrumbs = [
     { name: "Home", url: "https://mundengroup.ca" },
-    { name: "About", url: "https://mundengroup.ca/about" },
     {
       name: "Our History",
       url: "https://mundengroup.ca/about/history",

--- a/app/about/resources/[slug]/page.tsx
+++ b/app/about/resources/[slug]/page.tsx
@@ -78,7 +78,6 @@ export default async function ResourceArticlePage({ params }: Props) {
 
   const breadcrumbs = [
     { name: "Home", url: baseUrl },
-    { name: "About", url: `${baseUrl}/about` },
     {
       name: "Resources",
       url: `${baseUrl}/about/resources`,

--- a/app/about/resources/page.tsx
+++ b/app/about/resources/page.tsx
@@ -74,7 +74,6 @@ export default async function ResourcesPage({ searchParams }: ResourcesPageProps
   );
   const breadcrumbs = [
     { name: "Home", url: "https://mundengroup.ca" },
-    { name: "About", url: "https://mundengroup.ca/about" },
     {
       name: "Resources",
       url: "https://mundengroup.ca/about/resources",

--- a/app/equipment/ecolog/page.tsx
+++ b/app/equipment/ecolog/page.tsx
@@ -155,7 +155,6 @@ const support = [
 export default function EcoLogPage() {
   const breadcrumbs = [
     { name: "Home", url: "https://mundengroup.ca" },
-    { name: "Equipment", url: "https://mundengroup.ca/equipment" },
     {
       name: "EcoLog Forestry",
       url: "https://mundengroup.ca/equipment/ecolog",

--- a/app/equipment/forwarders/[model]/page.tsx
+++ b/app/equipment/forwarders/[model]/page.tsx
@@ -234,8 +234,8 @@ export default async function ForwarderDetailPage({ params }: Props) {
       {
         "@type": "ListItem",
         position: 2,
-        name: "Equipment",
-        item: "https://mundengroup.ca/equipment",
+        name: "EcoLog Forestry",
+        item: "https://mundengroup.ca/equipment/ecolog",
       },
       {
         "@type": "ListItem",

--- a/app/equipment/forwarders/page.tsx
+++ b/app/equipment/forwarders/page.tsx
@@ -124,8 +124,8 @@ export default function ForwardersPage() {
       {
         "@type": "ListItem",
         position: 2,
-        name: "Equipment",
-        item: "https://mundengroup.ca/equipment",
+        name: "EcoLog Forestry",
+        item: "https://mundengroup.ca/equipment/ecolog",
       },
       {
         "@type": "ListItem",

--- a/app/equipment/harvesters/[model]/page.tsx
+++ b/app/equipment/harvesters/[model]/page.tsx
@@ -295,8 +295,8 @@ export default async function HarvesterDetailPage({ params }: Props) {
       {
         "@type": "ListItem",
         position: 2,
-        name: "Equipment",
-        item: "https://mundengroup.ca/equipment",
+        name: "EcoLog Forestry",
+        item: "https://mundengroup.ca/equipment/ecolog",
       },
       {
         "@type": "ListItem",

--- a/app/equipment/harvesters/page.tsx
+++ b/app/equipment/harvesters/page.tsx
@@ -144,8 +144,8 @@ export default function HarvestersPage() {
       {
         "@type": "ListItem",
         position: 2,
-        name: "Equipment",
-        item: "https://mundengroup.ca/equipment",
+        name: "EcoLog Forestry",
+        item: "https://mundengroup.ca/equipment/ecolog",
       },
       {
         "@type": "ListItem",

--- a/app/services/mobile-service/page.tsx
+++ b/app/services/mobile-service/page.tsx
@@ -177,7 +177,6 @@ export default function MobileServicePage() {
 
   const breadcrumbs = [
     { name: "Home", url: "https://mundengroup.ca" },
-    { name: "Services", url: "https://mundengroup.ca/services" },
     {
       name: "Mobile Service",
       url: "https://mundengroup.ca/services/mobile-service",

--- a/app/services/parts-department/page.tsx
+++ b/app/services/parts-department/page.tsx
@@ -183,7 +183,6 @@ export default function PartsDepartmentPage() {
 
   const breadcrumbs = [
     { name: "Home", url: "https://mundengroup.ca" },
-    { name: "Services", url: "https://mundengroup.ca/services" },
     {
       name: "Parts Department",
       url: "https://mundengroup.ca/services/parts-department",

--- a/app/services/service-department/page.tsx
+++ b/app/services/service-department/page.tsx
@@ -431,7 +431,6 @@ export default function ServiceDepartmentPage() {
 
   const breadcrumbs = [
     { name: "Home", url: "https://mundengroup.ca" },
-    { name: "Services", url: "https://mundengroup.ca/services" },
     {
       name: "Service Department",
       url: "https://mundengroup.ca/services/service-department",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,12 @@
 import type { NextConfig } from "next";
 
+const canonicalHost = "mundengroup.ca";
+const redirectHosts = [
+  "www.mundengroup.ca",
+  "mundentruckequipment.com",
+  "www.mundentruckequipment.com",
+];
+
 const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
@@ -14,6 +21,27 @@ const nextConfig: NextConfig = {
   },
   async redirects() {
     return [
+      ...redirectHosts.map((host) => ({
+        source: "/:path*",
+        has: [{ type: "host" as const, value: host }],
+        destination: `https://${canonicalHost}/:path*`,
+        permanent: true,
+      })),
+      {
+        source: "/services",
+        destination: "/services/service-department",
+        permanent: true,
+      },
+      {
+        source: "/equipment",
+        destination: "/equipment/ecolog",
+        permanent: true,
+      },
+      {
+        source: "/about",
+        destination: "/about/history",
+        permanent: true,
+      },
       // Service page redirects
       {
         source: "/services/repair-shop",
@@ -84,12 +112,12 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/about/team",
-        destination: "/about",
+        destination: "/about/history",
         permanent: true,
       },
       {
         source: "/about/partners",
-        destination: "/about",
+        destination: "/about/history",
         permanent: true,
       },
       // News redirects

--- a/proxy.ts
+++ b/proxy.ts
@@ -15,7 +15,7 @@ export function proxy(request: NextRequest) {
     url.protocol = "https";
     url.hostname = canonicalHost;
     url.port = "";
-    return NextResponse.redirect(url, 308);
+    return NextResponse.redirect(url, { status: 308 });
   }
 
   const response = NextResponse.next();


### PR DESCRIPTION
## What

- Add permanent canonical-host redirects for www.mundengroup.ca and alternate Munden domains to https://mundengroup.ca.
- Redirect section roots (/about, /services, /equipment) to existing canonical pages instead of letting them 404.
- Remove dead section URLs from breadcrumb structured data, using only real canonical page URLs.

## Why

Google Search Console reported a duplicate canonical validation flow. The current live site already has canonical tags, but these changes make the preferred host and breadcrumb URL signals more explicit and prevent crawler-facing dead section URLs.

## Testing

- npm run lint (passes with existing config-file warnings)
- npm run build
- Local next start redirect checks: www/alternate hosts and /about, /services, /equipment all return 308 Permanent Redirect
- Rendered resources page no longer emits https://mundengroup.ca/about, /services, or /equipment breadcrumb targets

---
_Created by Codex workstation_