### PR TITLE
content: backfill July resource posts

### DIFF
--- a/.github/workflows/daily-blog.yml
+++ b/.github/workflows/daily-blog.yml
@@ -28,7 +28,7 @@ on:
       backfill_limit:
         description: "Maximum missing dates to generate in one run"
         required: false
-        default: "1"
+        default: "3"
         type: string
 
 permissions:
@@ -53,7 +53,7 @@ jobs:
       RUN_DATE: ${{ github.event.inputs.date }}
       BACKFILL_FROM: ${{ github.event.inputs.backfill_from }}
       BACKFILL_TO: ${{ github.event.inputs.backfill_to }}
-      BACKFILL_LIMIT: ${{ github.event.inputs.backfill_limit || '1' }}
+      BACKFILL_LIMIT: ${{ github.event.inputs.backfill_limit || '3' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/content/resources/2026-07-02-trailer-door-latch-and-landing-gear-problems-that-slow-down-freight.md
+++ b/content/resources/2026-07-02-trailer-door-latch-and-landing-gear-problems-that-slow-down-freight.md
@@ -1,0 +1,37 @@
+---
+title: "Trailer Door, Latch, and Landing Gear Problems That Slow Down Freight"
+slug: "trailer-door-latch-and-landing-gear-problems-that-slow-down-freight"
+date: "2026-07-02"
+excerpt: "Small trailer hardware problems can turn into loading delays, dock issues, and unsafe yard work. Here is what fleets should watch before a door, latch, or landing gear concern slows the next trip."
+category: "Parts and Service"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/equipment/blog1.jpeg"
+keywords: ["Kamloops trailer repair","commercial truck maintenance BC","truck and trailer parts","trailer repair","parts department"]
+sources: [{"title":"Munden Truck & Equipment Parts Department","url":"https://mundengroup.ca/services/parts-department"},{"title":"Munden Truck & Equipment Service Department","url":"https://mundengroup.ca/services/service-department"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"}]
+---
+
+## Small hardware problems create real delays
+Trailer doors, latches, hinges, rollers, and landing gear do not always get attention until something stops moving. A door that is hard to close, a latch that needs extra force, or a landing gear handle that binds can seem minor in the yard. At the dock, under a tight delivery window, those same problems can hold up freight and create a safety concern for the driver.
+
+The useful habit is to treat hardware complaints as early warnings. If a driver has to slam a door, kick a latch, or fight a crank handle, write it down before the part fails completely. Photos help too, especially when the concern involves bent brackets, worn rollers, cracked welds, missing fasteners, or corrosion around mounting points.
+
+## Watch the parts that take repeated abuse
+Door and landing gear problems usually build up through repeated use, vibration, weather, and loading damage. Roll-up doors can show problems at the tracks, rollers, cables, springs, panels, and bottom seal. Swing doors can show wear at hinges, keeper plates, handles, rods, and latch points. Landing gear can develop issues at the gearbox, crank handle, legs, shoes, cross shaft, or mounting brackets.
+
+The first clue is often feel. If the door does not move the way it normally does, or if the landing gear takes more effort than usual, something has changed. That change may be a lubrication issue, a bent component, worn hardware, or damage from a previous loading event. The sooner it is noted, the easier it is for the [parts department](/services/parts-department) to help identify what is needed.
+
+## Give the counter and shop useful details
+A parts call is faster when the first conversation includes the trailer make, model, year if available, unit number, VIN, photos, and where the damaged part sits on the trailer. If the old part has a stamping, label, or casting number, include that too. Measurements can also matter for hinges, rollers, handles, seals, pins, and landing gear components that look similar but do not interchange.
+
+For service planning, describe when the issue happens. Does the door bind only when the trailer is loaded? Does the latch pop open after rough roads? Does the landing gear crank smoothly until weight comes onto it? Those details help separate a simple part replacement from a mounting, alignment, or structural concern.
+
+## Do not wait for the fully stuck trailer
+Once a door will not secure, a latch will not hold, or landing gear will not support the trailer properly, the job gets more urgent. The trailer may need to stay parked until it can be inspected. That is especially true if a door cannot be safely closed, cargo cannot be secured, or the landing gear feels unstable under load.
+
+For Kamloops trailer repair and fleet maintenance, the better move is to schedule the repair while the unit can still be moved and parts can still be matched without pressure. If the concern is tied to damage, corrosion, or a previous repair, the [service department](/services/service-department) can check whether the surrounding structure is still sound.
+
+## Keep small notes from becoming big downtime
+Trailer hardware is easy to overlook because it is not always part of the power unit conversation. But freight still depends on it. A short note from the driver, a few photos, and a unit number can turn a vague complaint into a repair plan before the next pickup.
+
+When fleets pay attention to door, latch, and landing gear symptoms early, they reduce avoidable dock delays and keep the trailer safer to handle in the yard. That is a practical win for dispatch, drivers, customers, and the shop.

--- a/content/resources/2026-07-03-brake-shoe-and-drum-wear-signs-fleets-should-document-between-services.md
+++ b/content/resources/2026-07-03-brake-shoe-and-drum-wear-signs-fleets-should-document-between-services.md
@@ -1,0 +1,37 @@
+---
+title: "Brake Shoe and Drum Wear Signs Fleets Should Document Between Services"
+slug: "brake-shoe-and-drum-wear-signs-fleets-should-document-between-services"
+date: "2026-07-03"
+excerpt: "Brake wear is easier to manage when drivers and fleet managers document changes before the next inspection. These are the brake shoe and drum clues worth noting between scheduled services."
+category: "Maintenance Tips"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/news/steering-suspension.jpg"
+keywords: ["commercial truck maintenance BC","CVIP inspection Kamloops","Kamloops truck repair","brake wear","fleet maintenance"]
+sources: [{"title":"Munden Truck & Equipment Service Department","url":"https://mundengroup.ca/services/service-department"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"}]
+---
+
+## Driver notes can catch brake changes early
+Brake shoe and drum wear is not something most drivers measure during a normal day, but drivers can still notice when braking changes. Pulling to one side, a new vibration, a dragging feeling, heat smell, longer stopping distance, or a different sound during application are all notes worth passing along.
+
+Those observations matter because brake concerns rarely improve by being ignored. A small change can point to uneven wear, adjustment trouble, a sticking component, contamination, or heat damage. For commercial truck maintenance in BC, the goal is to catch those clues before they become an out-of-service problem or an avoidable repair during a busy week.
+
+## Pay attention to heat, smell, and feel
+Heat is one of the most useful warning signs. A wheel end that smells hot after a normal route, a drum that appears discoloured, or brakes that feel like they are dragging deserve attention. Drivers should not touch components to check temperature, but they can safely report smell, visible smoke, unusual dust, or a wheel position that seems different from the rest.
+
+Feel matters too. A vibration under braking can come from several causes, but it should be documented with speed, load, road condition, and whether it happens every time or only after a long descent. Pulling, grabbing, or inconsistent response should also be written down. Those details help the [service department](/services/service-department) decide what to inspect first.
+
+## Keep CVIP readiness in the conversation
+Brake wear is also a planning issue. If a unit is coming up for CVIP inspection, known brake concerns should not wait until the inspection bay finds them. Fleet managers can save time by reviewing driver notes, recent repairs, and any repeat complaints before booking the truck or trailer.
+
+That does not mean guessing at the repair. It means giving the shop useful history: which axle position is involved, when the symptom started, whether the unit runs loaded or empty most often, and whether the complaint changed after recent work. Clear history helps separate normal wear from a pattern that may need closer diagnosis.
+
+## Watch for contamination and uneven patterns
+Brake shoe condition can be affected by more than mileage. Oil contamination, damaged seals, dragging components, seized hardware, or adjustment concerns can all change how brakes wear. If a driver notices oily residue, heavy dust at one wheel position, or a new leak nearby, that note should be treated seriously.
+
+Uneven patterns across a fleet can also tell a story. If several trailers show similar brake concerns after the same route, yard, or loading condition, it may point to operating conditions rather than a single unit. If one truck keeps coming back with the same complaint, the repair history deserves a closer look.
+
+## Make the next service visit more productive
+Good brake notes do not need to be complicated. A unit number, date, route, load condition, symptom, and photo can be enough to move the conversation forward. If the issue affects safe operation, the unit should be evaluated before being dispatched again.
+
+For fleets around Kamloops, routine documentation helps the shop prioritize what needs immediate attention and what can be handled during planned downtime. It also supports better inspection readiness, fewer surprises, and cleaner communication between drivers, dispatch, and maintenance.

--- a/content/resources/2026-07-04-kingpin-and-suspension-wear-clues-that-show-up-during-everyday-driving.md
+++ b/content/resources/2026-07-04-kingpin-and-suspension-wear-clues-that-show-up-during-everyday-driving.md
@@ -1,0 +1,37 @@
+---
+title: "Kingpin and Suspension Wear Clues That Show Up During Everyday Driving"
+slug: "kingpin-and-suspension-wear-clues-that-show-up-during-everyday-driving"
+date: "2026-07-04"
+excerpt: "Kingpin and suspension wear often shows itself through steering feel, tire wear, clunks, and driver complaints. Here is what to document before everyday symptoms become bigger repairs."
+category: "Maintenance Tips"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/news/steering-suspension.jpg"
+keywords: ["Kamloops truck repair","commercial truck maintenance BC","steering and suspension","fleet maintenance","truck repair"]
+sources: [{"title":"Munden Truck & Equipment Service Department","url":"https://mundengroup.ca/services/service-department"},{"title":"Munden Truck & Equipment Mobile Service","url":"https://mundengroup.ca/services/mobile-service"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"}]
+---
+
+## Steering feel is often the first clue
+Kingpin and suspension wear can start quietly. A driver may notice that the truck wanders more than usual, needs constant correction, clunks over rough ground, or feels loose when turning into a yard. Those notes should not be brushed off as normal age or road condition without a closer look.
+
+The challenge is that steering and suspension concerns can feel similar from the seat. Tire pressure, alignment, loose components, worn bushings, shock issues, steering linkage, and kingpin wear can all change how the unit drives. That is why the driver note matters. When the symptom appears, where it is felt, and whether it changes loaded or empty can help the shop narrow the inspection.
+
+## Tire wear can support the story
+Uneven tire wear is not a diagnosis by itself, but it is useful evidence. Edge wear, cupping, feathering, or one tire position wearing faster than the others can support a complaint about steering feel or suspension movement. Fleet managers should pair tire observations with route history, recent tire work, and driver comments.
+
+Photos are helpful if they show the full tire position and a close view of the wear pattern. A short note like "right steer tire wearing outer edge faster after rough-road work" gives the [service department](/services/service-department) more to work with than "front end feels bad." The goal is not to solve the problem in the yard. It is to make the inspection more focused.
+
+## Clunks and looseness deserve detail
+A clunk over bumps, a knock during tight turns, or a loose feeling at low speed can point to worn or loose components. Drivers should note whether the sound comes from the front, rear, loaded trailer, or cab area. They should also note whether it happens while braking, turning, accelerating, or crossing uneven ground.
+
+If a symptom is getting worse, the truck should be booked sooner. Suspension and steering issues can affect tire life, driver confidence, and safe handling. For units working across the BC Interior, rough roads and heavy loads can make small wear show up faster than expected.
+
+## Do not separate comfort from safety
+A truck that feels loose or wanders is not just uncomfortable. It can increase driver fatigue and make the unit harder to control in traffic, wind, or tight yards. That is why everyday complaints should be documented before they become normal background noise.
+
+If the truck is away from the shop and the driver is unsure whether it should continue, a call to [mobile service](/services/mobile-service) can help decide whether field triage is appropriate or whether the unit needs to come in. The decision should be based on the symptom, severity, location, and whether safe operation is in question.
+
+## Build front-end checks into maintenance planning
+Kingpin and suspension issues are easier to handle when they are part of regular fleet planning. Keep driver notes with the unit record. Save photos of tire wear. Track repeat complaints after alignments, tire changes, or repairs. Over time, the pattern can show whether a unit needs routine adjustment, a deeper inspection, or a planned repair window.
+
+For Kamloops truck repair and commercial fleet maintenance, early documentation keeps the conversation practical. The sooner a driver reports a change in steering feel, tire wear, or suspension noise, the easier it is to protect uptime and avoid a more expensive surprise later.

--- a/content/resources/2026-07-05-harvester-head-wear-items-forestry-crews-should-track-between-services.md
+++ b/content/resources/2026-07-05-harvester-head-wear-items-forestry-crews-should-track-between-services.md
@@ -1,0 +1,37 @@
+---
+title: "Harvester Head Wear Items Forestry Crews Should Track Between Services"
+slug: "harvester-head-wear-items-forestry-crews-should-track-between-services"
+date: "2026-07-05"
+excerpt: "Harvester head wear can affect measuring, feeding, cutting, and uptime. These are the wear items forestry crews should track between services so parts and repairs are easier to plan."
+category: "Forestry Equipment"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/equipment/590g-harvester.jpg"
+keywords: ["forestry equipment Western Canada","EcoLog dealer Western Canada","EcoLog harvesters","forestry equipment support","parts department"]
+sources: [{"title":"Munden Truck & Equipment EcoLog Forestry Equipment","url":"https://mundengroup.ca/equipment/ecolog"},{"title":"EcoLog Forestry","url":"https://ecologforestry.com/"},{"title":"BC Forest Safety Council","url":"https://www.bcforestsafe.org/"},{"title":"Government of BC Forestry","url":"https://www2.gov.bc.ca/gov/content/industry/forestry"}]
+---
+
+## Wear tracking protects production time
+Harvester heads work in harsh conditions, and small wear items can affect the whole day. Feed rollers, knives, measuring wheels, hoses, saw components, pins, bushings, and guards all influence how efficiently the head handles timber. When one area starts slipping, the operator may notice it first as slower feeding, poor measuring consistency, rough delimbing, or more frequent adjustments.
+
+Those notes are worth keeping. A short operator report at the end of a shift can help the crew plan parts, schedule service, and avoid guessing when the machine is already down. For forestry equipment in Western Canada, uptime often depends on catching the pattern before the landing is waiting on a preventable repair.
+
+## Watch feeding and measuring behaviour
+If stems are not feeding cleanly, the cause may not be obvious from a distance. Roller wear, pressure settings, contamination, knife condition, or changing wood conditions can all affect performance. Operators should note when the issue happens, what size material is involved, and whether the concern is steady or intermittent.
+
+Measuring complaints deserve the same detail. If lengths seem inconsistent, write down when the difference appears and whether anything changed recently. A photo of the head, a note about species and conditions, and the machine serial number can help the [EcoLog forestry equipment support](/equipment/ecolog) conversation start in the right place.
+
+## Keep hoses and fittings in the daily walkaround
+Hydraulic hoses and fittings on a harvester head see movement, debris, vibration, and impact. Crews should look for abrasion, wet fittings, cracked covers, rubbing points, and areas where hose routing has changed. A small seep or rub mark is easier to plan around than a failed hose in the middle of a work block.
+
+Photos are especially useful for hose concerns. Show the wider area first, then a close view of the fitting, routing, or damage. If a hose has markings, include those too. That information can help the [parts department](/services/parts-department) check options before the machine is parked.
+
+## Do not ignore cutting and delimbing changes
+Cutting performance and delimbing quality can also point to wear. Dull, damaged, or misadjusted components may show up as slower cycles, rougher stems, more operator corrections, or extra strain on the machine. Crews should avoid turning every symptom into a parts order, but they should document changes clearly enough that service can inspect the right area.
+
+The same applies to pins, bushings, guards, and mounting points. Movement, noise, or visible damage should be noted before it becomes a larger repair. In remote work, a minor issue can become expensive simply because of travel, access, and lost production.
+
+## Make the next parts call easier
+Good forestry parts support starts with identification. Keep the machine model, serial number, head model, photos, old part numbers if available, and a plain description of the symptom. If the crew has already adjusted, cleaned, or replaced something, include that history.
+
+For contractors running harvesters and forwarders across the Interior, that discipline helps the service and parts conversation move faster. It also gives managers a clearer view of which wear items are normal, which ones are repeating too often, and which repairs should be planned before the next remote job.

--- a/content/resources/2026-07-06-cab-entry-steps-mirrors-and-safety-hardware-that-deserve-routine-checks.md
+++ b/content/resources/2026-07-06-cab-entry-steps-mirrors-and-safety-hardware-that-deserve-routine-checks.md
@@ -1,0 +1,37 @@
+---
+title: "Cab Entry Steps, Mirrors, and Safety Hardware That Deserve Routine Checks"
+slug: "cab-entry-steps-mirrors-and-safety-hardware-that-deserve-routine-checks"
+date: "2026-07-06"
+excerpt: "Loose steps, damaged mirrors, weak grab handles, and worn safety hardware can create everyday risk. These routine checks help fleets catch simple problems before they affect drivers or inspections."
+category: "Maintenance Tips"
+author: "Munden Truck & Equipment Ltd."
+readTime: "3 min read"
+image: "/images/equipment/blog1.jpeg"
+keywords: ["commercial truck maintenance BC","Kamloops truck repair","fleet maintenance","CVIP inspection Kamloops","truck repair"]
+sources: [{"title":"Munden Truck & Equipment Service Department","url":"https://mundengroup.ca/services/service-department"},{"title":"BC Commercial Vehicle Safety and Enforcement","url":"https://www2.gov.bc.ca/gov/content/transportation/vehicle-safety-enforcement"},{"title":"BC Trucking Association","url":"https://www.bctrucking.com/"}]
+---
+
+## Everyday hardware still affects safety
+Cab entry steps, grab handles, mirrors, mudflaps, marker brackets, and other safety hardware can feel secondary compared with engine, brake, or driveline work. But drivers use those parts every day. A loose step, cracked mirror mount, missing fastener, or damaged handle can create risk long before it becomes a major repair.
+
+These items are also easy to miss when everyone is focused on bigger complaints. The truck still starts, the trailer still pulls, and the route still runs. Then a driver climbs in during bad weather, a mirror shifts on rough road, or a small bracket finally gives up. Routine checks help prevent that kind of avoidable interruption.
+
+## Look for movement, corrosion, and missing hardware
+The first check is simple: does the part move the way it should? Steps should feel secure. Grab handles should not flex loosely. Mirrors should hold position. Guards, brackets, and exterior hardware should not rattle, sag, or hang from one fastener.
+
+Corrosion deserves attention too. Rust around a mounting point can weaken the area around an otherwise normal-looking part. Cracked plastic, bent brackets, sharp edges, missing caps, and loose fasteners should all be written down. If the issue affects safe entry, visibility, or securement, it should move up the maintenance list instead of waiting for a convenient day.
+
+## Drivers should report visibility changes quickly
+Mirrors and visibility hardware are not cosmetic. If a mirror vibrates, will not adjust, is cracked, or does not stay in place, the driver should report it before the next trip. The same goes for lighting brackets, reflectors, and hardware that affects how the unit is seen in the yard or on the road.
+
+Photos help the [service department](/services/service-department) understand whether the concern looks like a quick replacement, a mounting issue, or possible surrounding damage. Include the unit number, side of the truck, and whether the part was damaged by impact, vibration, weather, or normal wear.
+
+## Tie small checks to inspection readiness
+Cab and exterior hardware checks fit naturally into preventive maintenance and inspection planning. Before a CVIP appointment, fleet managers should review driver notes for loose steps, missing hardware, damaged mirrors, broken brackets, and anything that could affect safe operation. That review can prevent a simple parts issue from becoming a last-minute scramble.
+
+It also helps with scheduling. A minor mirror or handle repair may be easy if parts are available. If the mount is damaged, corroded, or tied into other body work, the repair may need more time. Sending photos early gives the shop and [parts department](/services/parts-department) a better chance to prepare.
+
+## Build the habit into walkarounds
+Drivers do not need a complicated process. They need permission to report small hardware issues before those issues become normal. A note like "driver-side lower step loose after yard contact" or "right mirror shakes at highway speed" gives maintenance something useful to act on.
+
+For fleets working around Kamloops and across the BC Interior, routine attention to cab entry and safety hardware protects drivers, supports inspection readiness, and reduces avoidable downtime. It is a small habit, but it keeps the truck easier and safer to use every day.


### PR DESCRIPTION
## What

Backfills the missing July 2-6 resource posts so the blog is current again after the daily automation fell behind.

## Changes

- Added five date-consistent resource posts for July 2 through July 6, 2026.
- Kept article metadata aligned with the existing resource frontmatter format.
- Increased the daily blog workflow backfill default from 1 to 3 so scheduled runs can recover from small gaps.

## Testing

- npm run blog:validate
- npm run lint
- npm run build

---
_Created by Codex workstation_