### PR TITLE
fix: align local search location signals

### DIFF
--- a/app/about/contact/page.tsx
+++ b/app/about/contact/page.tsx
@@ -31,6 +31,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { googleMapsEmbedUrl } from "@/lib/site";
 
 const formSchema = z.object({
   name: z.string().min(2, "Name must be at least 2 characters"),
@@ -357,13 +358,13 @@ export default function ContactPage() {
         <Card className="mt-12 max-w-6xl mx-auto">
           <CardContent className="p-0 overflow-hidden rounded-lg">
             <iframe
-              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2540.1839889687844!2d-120.32891602337467!3d50.67009607167635!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x537e2c8b8b8b8b8b%3A0x8b8b8b8b8b8b8b8b!2s725%20Carrier%20St%2C%20Kamloops%2C%20BC%20V2H%201G1!5e0!3m2!1sen!2sca!4v1700000000000!5m2!1sen!2sca"
+              src={googleMapsEmbedUrl}
               width="100%"
               height="400"
               style={{ border: 0 }}
               allowFullScreen
               loading="lazy"
-              referrerPolicy="no-referrer-when-downgrade"
+              referrerPolicy="strict-origin-when-cross-origin"
               title="Munden Truck & Equipment Location"
             />
           </CardContent>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -6,6 +6,7 @@ import { ChevronLeft } from "lucide-react";
 import StructuredData, {
   breadcrumbSchema,
 } from "@/components/seo/StructuredData";
+import { businessContact, businessLocation } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "Privacy Policy | Munden Truck & Equipment Ltd.",
@@ -186,13 +187,20 @@ export default function PrivacyPage() {
                 <address className="not-italic">
                   Munden Truck & Equipment Ltd.
                   <br />
-                  123 Industrial Way
+                  {businessLocation.streetAddress}
                   <br />
-                  Kamloops, BC V2C 1A1
+                  {businessLocation.addressLocality},{" "}
+                  {businessLocation.addressRegion} {businessLocation.postalCode}
                   <br />
-                  Email: privacy@mundengroup.ca
+                  Email:{" "}
+                  <a href={`mailto:${businessContact.email}`}>
+                    {businessContact.email}
+                  </a>
                   <br />
-                  Phone: 1-800-XXX-XXXX
+                  Phone:{" "}
+                  <a href={businessContact.phoneHref}>
+                    {businessContact.phoneDisplay}
+                  </a>
                 </address>
               </CardContent>
             </Card>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -6,6 +6,7 @@ import { ChevronLeft } from "lucide-react";
 import StructuredData, {
   breadcrumbSchema,
 } from "@/components/seo/StructuredData";
+import { businessContact, businessLocation } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "Terms of Service | Munden Truck & Equipment Ltd.",
@@ -195,13 +196,20 @@ export default function TermsPage() {
                 <address className="not-italic">
                   Munden Truck & Equipment Ltd.
                   <br />
-                  123 Industrial Way
+                  {businessLocation.streetAddress}
                   <br />
-                  Kamloops, BC V2C 1A1
+                  {businessLocation.addressLocality},{" "}
+                  {businessLocation.addressRegion} {businessLocation.postalCode}
                   <br />
-                  Email: legal@mundengroup.ca
+                  Email:{" "}
+                  <a href={`mailto:${businessContact.email}`}>
+                    {businessContact.email}
+                  </a>
                   <br />
-                  Phone: 1-800-XXX-XXXX
+                  Phone:{" "}
+                  <a href={businessContact.phoneHref}>
+                    {businessContact.phoneDisplay}
+                  </a>
                 </address>
               </CardContent>
             </Card>

--- a/components/sections/LocationSection.tsx
+++ b/components/sections/LocationSection.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Phone, Mail, MapPin, Clock } from "lucide-react"
 import { motion } from "framer-motion"
+import { googleMapsEmbedUrl } from "@/lib/site"
 
 const LocationSection = () => {
   return (
@@ -35,13 +36,13 @@ const LocationSection = () => {
             <Card className="overflow-hidden">
               <CardContent className="p-0">
                 <iframe
-                  src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2540.1839889687844!2d-120.32891602337467!3d50.67009607167635!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x537e2c8b8b8b8b8b%3A0x8b8b8b8b8b8b8b8b!2s725%20Carrier%20St%2C%20Kamloops%2C%20BC%20V2H%201G1!5e0!3m2!1sen!2sca!4v1700000000000!5m2!1sen!2sca"
+                  src={googleMapsEmbedUrl}
                   width="100%"
                   height="350"
                   style={{ border: 0 }}
                   allowFullScreen
                   loading="lazy"
-                  referrerPolicy="no-referrer-when-downgrade"
+                  referrerPolicy="strict-origin-when-cross-origin"
                   title="Munden Truck & Equipment Location"
                 />
               </CardContent>

--- a/components/seo/StructuredData.tsx
+++ b/components/seo/StructuredData.tsx
@@ -1,5 +1,10 @@
 import { FC } from "react";
-import { absoluteUrl, siteUrl } from "@/lib/site";
+import {
+  absoluteUrl,
+  businessLocation,
+  googleMapsPlaceUrl,
+  siteUrl,
+} from "@/lib/site";
 
 interface StructuredDataProps {
   data: Record<string, unknown> | Record<string, unknown>[];
@@ -42,17 +47,18 @@ export const localBusinessSchema = {
   telephone: "+1-250-828-2268",
   address: {
     "@type": "PostalAddress",
-    streetAddress: "725 Carrier Street",
-    addressLocality: "Kamloops",
-    addressRegion: "BC",
-    postalCode: "V2H 1G1",
-    addressCountry: "CA",
+    streetAddress: businessLocation.streetAddress,
+    addressLocality: businessLocation.addressLocality,
+    addressRegion: businessLocation.addressRegion,
+    postalCode: businessLocation.postalCode,
+    addressCountry: businessLocation.addressCountry,
   },
   geo: {
     "@type": "GeoCoordinates",
-    latitude: 50.674522,
-    longitude: -120.32785,
+    latitude: businessLocation.latitude,
+    longitude: businessLocation.longitude,
   },
+  hasMap: googleMapsPlaceUrl,
   openingHoursSpecification: [
     {
       "@type": "OpeningHoursSpecification",
@@ -70,6 +76,7 @@ export const localBusinessSchema = {
     },
   ],
   sameAs: [
+    googleMapsPlaceUrl,
     "https://www.facebook.com/MundenGroup/",
     "https://ca.linkedin.com/company/mundengroup",
   ],
@@ -166,8 +173,8 @@ export const serviceSchema = (service: {
     "@type": "GeoCircle",
     geoMidpoint: {
       "@type": "GeoCoordinates",
-      latitude: 50.674522,
-      longitude: -120.32785,
+      latitude: businessLocation.latitude,
+      longitude: businessLocation.longitude,
     },
     geoRadius: service.areaServed || "250km",
   },
@@ -250,11 +257,11 @@ export const organizationSchema = {
     "Munden Truck & Equipment - Kamloops truck repair, trailer repair, equipment repair. Truck shop, trailer shop, automotive shop. CVIP inspections, mobile service truck, emergency roadside service. Welding, fabrication, hydraulics. Refrigeration, A/C repair. Carrier, Thermo King, Webasto service. Truck parts and trailer parts.",
   address: {
     "@type": "PostalAddress",
-    streetAddress: "725 Carrier Street",
-    addressLocality: "Kamloops",
-    addressRegion: "BC",
-    postalCode: "V2H 1G1",
-    addressCountry: "CA",
+    streetAddress: businessLocation.streetAddress,
+    addressLocality: businessLocation.addressLocality,
+    addressRegion: businessLocation.addressRegion,
+    postalCode: businessLocation.postalCode,
+    addressCountry: businessLocation.addressCountry,
   },
   contactPoint: [
     {

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,6 +1,22 @@
 export const siteUrl = "https://mundengroup.ca";
 export const canonicalHost = "mundengroup.ca";
 
+export const businessLocation = {
+  streetAddress: "725 Carrier St",
+  addressLocality: "Kamloops",
+  addressRegion: "BC",
+  postalCode: "V2H 1G1",
+  addressCountry: "CA",
+  latitude: 50.6850629,
+  longitude: -120.318686,
+} as const;
+
+export const googleMapsPlaceUrl =
+  "https://www.google.com/maps?cid=2171221372270048230";
+
+export const googleMapsEmbedUrl =
+  "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2527.879434860647!2d-120.31868599999999!3d50.68506289999999!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x537e2d099230fc25%3A0x1e21ba559ee473e6!2sMunden%20Truck%20%26%20Equipment%20Ltd.!5e0!3m2!1sen!2sca!4v1784135669551!5m2!1sen!2sca";
+
 export function absoluteUrl(path = "/") {
   if (path.startsWith("http://") || path.startsWith("https://")) {
     return path;

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -11,6 +11,12 @@ export const businessLocation = {
   longitude: -120.318686,
 } as const;
 
+export const businessContact = {
+  phoneDisplay: "250-828-2268",
+  phoneHref: "tel:+12508282268",
+  email: "kamloops.shop@mundengroup.ca",
+} as const;
+
 export const googleMapsPlaceUrl =
   "https://www.google.com/maps?cid=2171221372270048230";
 


### PR DESCRIPTION
## What

Align the website's local-search location data with the verified Munden Truck & Equipment Google Maps listing.

## Changes

- Centralize the verified address, coordinates, Google Maps place URL, and canonical embed URL
- Correct LocalBusiness and service-area structured-data coordinates
- Link the structured business entity to the verified Google Maps listing
- Replace malformed homepage and contact-page map embeds
- Replace placeholder privacy/terms address, email, and phone details with the real business contact information
- Make legal-page email and phone details actionable links

## Verification

- `npm run lint` (passes with two pre-existing config warnings)
- `npm run build`
- Desktop and mobile visual checks of the homepage map
- Desktop visual check of the contact-page map
- Built HTML checks for corrected coordinates, Maps entity link, address, phone, and email
- Placeholder and old-coordinate sweep across production app code

## Note

A standalone `npx tsc --noEmit` exposes two pre-existing type errors in `app/services/service-department/page.tsx`; the file is unchanged by this PR and the repository has no typecheck script. The required production build passes.

---
_Created by Codex workstation_